### PR TITLE
Add SDK usage guidance

### DIFF
--- a/docs/issues/ISSUE-236-SUBTASKS.md
+++ b/docs/issues/ISSUE-236-SUBTASKS.md
@@ -6,6 +6,6 @@ Tracking subtasks required to deliver the shared SDK effort.
 |----|-------------|-------|--------|-------|
 | [236A](https://github.com/c-daly/logos/issues/253) | Author `sophia.openapi.yaml` describing `/health`, `/plan`, `/state`, `/simulate` per Phase 2 spec | LOGOS | In Progress | current PR |
 | [236B](https://github.com/c-daly/logos/issues/254) | Set up OpenAPI codegen pipeline and commit generated SDKs under `sdk/` (Python) and `sdk-web/` (TypeScript) | LOGOS | In Progress | `scripts/generate-sdks.sh` uses openapi-generator CLI |
-| [236C](https://github.com/c-daly/logos/issues/255) | Document SDK usage + versioning/publish steps (`docs/sdk/README.md`) | LOGOS | TODO | includes local install instructions |
+| [236C](https://github.com/c-daly/logos/issues/255) | Document SDK usage + versioning/publish steps (`docs/sdk/README.md`) | LOGOS | In Progress | README outlines install/version instructions |
 | [236D](https://github.com/c-daly/logos/issues/256) | Add CI workflow to regenerate/verify SDKs when contracts change | LOGOS | TODO | e.g., `.github/workflows/sdk-regenerate.yml` |
 | [236E](https://github.com/c-daly/logos/issues/257) | Refactor Apollo CLI/browser to consume the generated SDKs | Apollo | TODO | separate repo follow-up |

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,0 +1,80 @@
+# LOGOS SDKs
+
+Shared client SDKs allow the CLI, browser, and automation jobs to consume the Sophia and Hermes APIs without hand-written HTTP glue. This directory documents how to install, regenerate, and publish the generated packages.
+
+## Available Packages
+
+### Python (sdk/)
+- `sdk/python/sophia` → `logos_sophia_sdk`
+- `sdk/python/hermes` → `logos_hermes_sdk`
+
+### TypeScript (sdk-web/)
+- `sdk-web/sophia` → `@logos/sophia-sdk`
+- `sdk-web/hermes` → `@logos/hermes-sdk`
+
+The packages are generated from the OpenAPI contracts in `contracts/`.
+
+## Regenerating SDKs
+
+Whenever `contracts/sophia.openapi.yaml` or `contracts/hermes.openapi.yaml` change, regenerate all SDKs:
+
+```bash
+./scripts/generate-sdks.sh
+```
+
+Requirements:
+- Node.js/npm (script uses `npx @openapitools/openapi-generator-cli`)
+
+The script overwrites everything under `sdk/` and `sdk-web/`. Always commit the regenerated files.
+
+## Installing Locally
+
+### Python
+
+From the desired SDK directory:
+
+```bash
+cd sdk/python/sophia
+pip install .
+```
+
+or for development:
+
+```bash
+pip install -e .
+```
+
+Then import in your project:
+
+```python
+from logos_sophia_sdk import Configuration, PlanningApi
+```
+
+Repeat with `sdk/python/hermes` for Hermes.
+
+### TypeScript / JavaScript
+
+Link locally using `npm`:
+
+```bash
+cd sdk-web/sophia
+npm install
+npm pack  # produces a tarball
+```
+
+Then install that tarball in the consumer project, or use `npm link` for development. Once published to an npm registry, install via `npm install @logos/sophia-sdk`.
+
+## Versioning & Publishing
+
+Generated packages default to version `0.1.0`. When cutting a release:
+1. Update `packageVersion`/`npmVersion` in `scripts/generate-sdks.sh` (or edit the generated `pyproject.toml`/`package.json`).
+2. Regenerate and commit.
+3. Publish:
+   - Python: `cd sdk/python/<name> && python -m build && twine upload dist/*` (requires credentials).
+   - TypeScript: `cd sdk-web/<name> && npm publish` (configure registry as needed).
+
+Document published versions in release notes so downstream clients can pin known-good builds.
+
+## Continuous Integration
+
+Future work (Issue #256) will add a GitHub Actions workflow to regenerate SDKs when contracts change and fail if generated files are out of date. Until then, run `./scripts/generate-sdks.sh` manually before submitting PRs that touch `contracts/`.


### PR DESCRIPTION
## Summary
- add docs/sdk/README.md describing the shared Sophia/Hermes SDKs, how to regenerate them, install locally, bump versions, and publish
- update docs/issues/ISSUE-236-SUBTASKS.md to mark subtask #255 as in progress

## Testing
- docs-only
