### PR TITLE
Add SDK regen workflow

### DIFF
--- a/.github/workflows/sdk-regen.yml
+++ b/.github/workflows/sdk-regen.yml
@@ -1,0 +1,39 @@
+name: SDK Regeneration Check
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/**'
+      - 'scripts/generate-sdks.sh'
+      - 'openapitools.json'
+      - '.github/workflows/sdk-regen.yml'
+  pull_request:
+    paths:
+      - 'contracts/**'
+      - 'scripts/generate-sdks.sh'
+      - 'openapitools.json'
+      - '.github/workflows/sdk-regen.yml'
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Regenerate SDKs
+        run: ./scripts/generate-sdks.sh
+
+      - name: Ensure no uncommitted changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "::error::SDK outputs are stale. Run ./scripts/generate-sdks.sh and commit the changes." >&2
+            git status --short
+            exit 1
+          fi

--- a/docs/issues/ISSUE-236-SUBTASKS.md
+++ b/docs/issues/ISSUE-236-SUBTASKS.md
@@ -7,5 +7,5 @@ Tracking subtasks required to deliver the shared SDK effort.
 | [236A](https://github.com/c-daly/logos/issues/253) | Author `sophia.openapi.yaml` describing `/health`, `/plan`, `/state`, `/simulate` per Phase 2 spec | LOGOS | In Progress | current PR |
 | [236B](https://github.com/c-daly/logos/issues/254) | Set up OpenAPI codegen pipeline and commit generated SDKs under `sdk/` (Python) and `sdk-web/` (TypeScript) | LOGOS | In Progress | `scripts/generate-sdks.sh` uses openapi-generator CLI |
 | [236C](https://github.com/c-daly/logos/issues/255) | Document SDK usage + versioning/publish steps (`docs/sdk/README.md`) | LOGOS | In Progress | README outlines install/version instructions |
-| [236D](https://github.com/c-daly/logos/issues/256) | Add CI workflow to regenerate/verify SDKs when contracts change | LOGOS | TODO | e.g., `.github/workflows/sdk-regenerate.yml` |
+| [236D](https://github.com/c-daly/logos/issues/256) | Add CI workflow to regenerate/verify SDKs when contracts change | LOGOS | In Progress | `.github/workflows/sdk-regen.yml` ensures outputs are up to date |
 | [236E](https://github.com/c-daly/logos/issues/257) | Refactor Apollo CLI/browser to consume the generated SDKs | Apollo | TODO | separate repo follow-up |

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -77,4 +77,4 @@ Document published versions in release notes so downstream clients can pin known
 
 ## Continuous Integration
 
-Future work (Issue #256) will add a GitHub Actions workflow to regenerate SDKs when contracts change and fail if generated files are out of date. Until then, run `./scripts/generate-sdks.sh` manually before submitting PRs that touch `contracts/`.
+The `sdk-regen` GitHub Actions workflow runs `./scripts/generate-sdks.sh` on every PR/push that touches the contracts or generator inputs. If regenerated files differ from what is committed, the job fails with instructions to rerun the script locally and add the changes.


### PR DESCRIPTION
## Summary
- add .github/workflows/sdk-regen.yml to rerun ./scripts/generate-sdks.sh when contracts/tooling change and fail if outputs differ (addresses #256)
- update docs/sdk/README.md to describe the new CI enforcement
- mark subtask 236D as in progress in docs/issues/ISSUE-236-SUBTASKS.md

## Testing
- docs/workflow change only
