### PR TITLE
Add scenario benchmark scaffolding

### DIFF
--- a/docs/research/MAKE_LOGOS_GREAT_AGAIN.md
+++ b/docs/research/MAKE_LOGOS_GREAT_AGAIN.md
@@ -59,6 +59,8 @@ Use this as a reference when creating new benchmark bundles.
 - `milvus_dump.tar.gz`: `python scripts/export_milvus.py --collection scenario_embodied_loop --output logs/benchmarks/embodied_loop/milvus_dump.tar.gz`.
 Document deviations or additional files in the scenario README.
 
+See `logs/benchmarks/README.md` and the scenario-specific subfolder READMEs for detailed capture steps.
+
 ---
 
 ## 2. Automated Metrics

--- a/logs/benchmarks/README.md
+++ b/logs/benchmarks/README.md
@@ -1,0 +1,14 @@
+# Scenario Benchmark Bundles
+
+Each folder under `logs/benchmarks/` captures the artifacts needed to replay a canonical LOGOS scenario. Use these bundles when preparing verification evidence or running the Scenario Coverage Index tooling (see docs/phase2/METRICS_IDEAS.md).
+
+## Required Artifacts per Scenario
+- `README.md` — context, prerequisites, replay steps.
+- `replay.sh` — script or command list to reproduce the run.
+- `cwm_state.jsonl` — serialized CWMState emissions.
+- `plan.log` / `state.log` — API transcripts.
+- `personas.jsonl` — PersonaEntry events.
+- `jepe_frames/` — imagined frames (if applicable).
+- `talos_telemetry.jsonl` — actuator/sensor traces for embodied runs.
+
+Populate each bundle with real data before submitting verification evidence; placeholder files below describe the expectations.

--- a/logs/benchmarks/browser_llm/README.md
+++ b/logs/benchmarks/browser_llm/README.md
@@ -1,0 +1,23 @@
+# Scenario: Browser + LLM Co-Processor
+
+## Goal
+Capture an Apollo browser session where the embedded LLM proposes actions and Sophia validates them via the shared SDK, including gullibility/conflict logging.
+
+## Prerequisites
+- Sophia/Hermes services with persona pipeline enabled
+- Apollo browser configured with LLM provider credentials
+
+## Capture Steps
+1. Start services and browser front-end.
+2. Use `./replay.sh` (or manual steps) to run a scripted conversation.
+3. Save chat transcripts along with the artifacts below.
+
+## Artifacts
+- `cwm_state.jsonl`
+- `plan.log`
+- `state.log`
+- `personas.jsonl`
+- `jepe_frames/` (if `/simulate` invoked)
+
+## Notes
+Note prompts, LLM model, and conflicts detected for gullibility metrics.

--- a/logs/benchmarks/browser_llm/replay.sh
+++ b/logs/benchmarks/browser_llm/replay.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# TODO: implement replay commands for this scenario.
+# Document environment variables, CLI calls, and any Talos/Apollo actions.

--- a/logs/benchmarks/cli_only_ops/README.md
+++ b/logs/benchmarks/cli_only_ops/README.md
@@ -1,0 +1,23 @@
+# Scenario: CLI-Only Operations
+
+## Goal
+Run a goal→plan→diagnostics cycle entirely from the Apollo CLI, exercising shared SDK output and persona logging without the browser.
+
+## Prerequisites
+- Sophia/Hermes services running
+- Apollo CLI installed (points to local cluster)
+
+## Capture Steps
+1. Start services.
+2. Execute `./replay.sh` or run equivalent CLI commands (e.g., `logos plan create ...`).
+3. Stream logs until the plan completes and diagnostics stabilize.
+4. Archive artifacts below.
+
+## Artifacts
+- `cwm_state.jsonl`
+- `plan.log`
+- `state.log`
+- `personas.jsonl`
+
+## Notes
+Document CLI commands issued, tokens used, and any anomalies observed.

--- a/logs/benchmarks/cli_only_ops/replay.sh
+++ b/logs/benchmarks/cli_only_ops/replay.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# TODO: implement replay commands for this scenario.
+# Document environment variables, CLI calls, and any Talos/Apollo actions.

--- a/logs/benchmarks/embodied_loop/README.md
+++ b/logs/benchmarks/embodied_loop/README.md
@@ -1,0 +1,26 @@
+# Scenario: Embodied Loop
+
+## Goal
+Talos (physical or simulated) performs the pick-and-place loop used in demos, exercising JEPA predictions and persona reflections during execution.
+
+## Prerequisites
+- HCG dev cluster + Sophia/Hermes services running
+- Talos simulator or hardware profile configured
+- Apollo CLI/browser connected to Sophia
+
+## Capture Steps
+1. Start the infrastructure (`docker compose -f infra/docker-compose.hcg.dev.yml up -d`).
+2. Launch Talos simulator/hardware.
+3. Execute `./replay.sh` to run the scripted goal, or reproduce the steps manually via Apollo.
+4. Export Neo4j/Milvus evidence as described below.
+
+## Artifacts
+- `cwm_state.jsonl`
+- `plan.log`
+- `state.log`
+- `personas.jsonl`
+- `jepe_frames/`
+- `talos_telemetry.jsonl`
+
+## Notes
+Document entities involved, hardware configuration, and links to screenshots/video.

--- a/logs/benchmarks/embodied_loop/replay.sh
+++ b/logs/benchmarks/embodied_loop/replay.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# TODO: implement replay commands for this scenario.
+# Document environment variables, CLI calls, and any Talos/Apollo actions.

--- a/logs/benchmarks/swappable_hardware/README.md
+++ b/logs/benchmarks/swappable_hardware/README.md
@@ -1,0 +1,23 @@
+# Scenario: Swappable Hardware
+
+## Goal
+Run the same plan twice—once against a simulator, once against physical Talos hardware—and show that Sophia’s API outputs remain identical aside from telemetry.
+
+## Prerequisites
+- Access to both Talos simulator and hardware configuration
+- Sophia/Hermes services running
+
+## Capture Steps
+1. Execute `./replay.sh sim` to run the simulation capture.
+2. Execute `./replay.sh hardware` for the physical run.
+3. Store both sets of artifacts in this directory (different subfolders if desired).
+
+## Artifacts
+- `cwm_state.jsonl` (per run)
+- `plan.log`
+- `state.log`
+- `personas.jsonl`
+- `talos_telemetry.jsonl`
+
+## Notes
+Describe differences between hardware modes and link to video evidence.

--- a/logs/benchmarks/swappable_hardware/replay.sh
+++ b/logs/benchmarks/swappable_hardware/replay.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# TODO: implement replay commands for this scenario.
+# Document environment variables, CLI calls, and any Talos/Apollo actions.

--- a/logs/benchmarks/talos_free_perception/README.md
+++ b/logs/benchmarks/talos_free_perception/README.md
@@ -1,0 +1,25 @@
+# Scenario: Talos-Free Perception
+
+## Goal
+Demonstrate the browser upload → JEPA prediction path without Talos, capturing how Sophia logs imagined states and surface diagnostics.
+
+## Prerequisites
+- Sophia/Hermes services running
+- Apollo browser configured
+- Sample media clip(s) for upload
+
+## Capture Steps
+1. Start services (`docker compose ...`).
+2. From Apollo browser, upload the prepared media via the perception panel.
+3. Run `./replay.sh` to automate the upload if desired.
+4. Collect artifacts listed below.
+
+## Artifacts
+- `cwm_state.jsonl`
+- `plan.log`
+- `state.log`
+- `personas.jsonl`
+- `jepe_frames/`
+
+## Notes
+Record media sample IDs, JEPA model version, and any assumptions used.

--- a/logs/benchmarks/talos_free_perception/replay.sh
+++ b/logs/benchmarks/talos_free_perception/replay.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# TODO: implement replay commands for this scenario.
+# Document environment variables, CLI calls, and any Talos/Apollo actions.


### PR DESCRIPTION
## Summary
- add placeholder benchmark folders under logs/benchmarks/ for each required scenario (embodied loop, Talos-free perception, CLI-only ops, browser+LLM, swappable hardware)
- include READMEs and replay.sh stubs describing capture steps and required artifacts so teams can start filling them with real data
- link the new structure from docs/research/MAKE_LOGOS_GREAT_AGAIN.md

## Testing
- docs/structure only

Fixes #262
