### PR TITLE
Add Apollo LLM-only demo guide

### DIFF
--- a/docs/demo/APOLLO_LLM_ONLY.md
+++ b/docs/demo/APOLLO_LLM_ONLY.md
@@ -9,7 +9,7 @@ This guide captures the steps required to run the Apollo web experience in "LLM-
 1. **Latest repos**: pull `logos`, `sophia`, `hermes`, and `apollo` (main branches).
 2. **Dev dependencies**: Node.js 18+, Python 3.11+, Poetry, Docker (for the HCG cluster).
 3. **Shared SDKs**: from the `logos` repo run `./scripts/generate-sdks.sh` so `sdk-web/sophia` and `sdk-web/hermes` are up to date.
-4. **Hermes LLM provider**: set env vars for the provider you want to call (e.g., `HERMES_LLM_PROVIDER=openai`, `HERMES_LLM_API_KEY=...`). Hermes will expose an `/llm` endpoint per ADR-0006.
+4. **Hermes LLM provider**: set env vars for the provider you want to call (e.g., `HERMES_LLM_PROVIDER=openai`, `HERMES_LLM_API_KEY=...`). Hermes will expose an `/llm` endpoint per ADR-0006 (implementation tracked by issue #279).
 
 ## 2. Start Core Services
 
@@ -62,8 +62,8 @@ Workflow suggestions:
 
 After completing the demo, populate `logs/benchmarks/browser_llm/`:
 
-1. Save the `/plan` and `/state` HTTP transcripts (e.g., rerun the requests via `curl` and pipe to `plan.log`, `state.log`).
-2. Export CWM states via Cypher or an admin script (see issue #276 for upcoming helpers) and store as `cwm_state.jsonl`.
+1. Save the `/plan` and `/state` HTTP transcripts (e.g., rerun the requests via `curl` and pipe to `plan.log`, `state.log`). (Export helper scripts are being added via issue #276.)
+2. Export CWM states via Cypher or an admin script (see issue #276 for the forthcoming helper) and store as `cwm_state.jsonl`.
 3. Dump persona entries via the `logos_persona` API (`curl http://localhost:8000/persona/entries`) and save as `personas.jsonl`.
 4. Capture screenshots/video of the webapp and note paths in `README.md`.
 

--- a/logs/benchmarks/README.md
+++ b/logs/benchmarks/README.md
@@ -11,4 +11,4 @@ Each folder under `logs/benchmarks/` captures the artifacts needed to replay a c
 - `jepe_frames/` — imagined frames (if applicable).
 - `talos_telemetry.jsonl` — actuator/sensor traces for embodied runs.
 
-Populate each bundle with real data before submitting verification evidence; placeholder files below describe the expectations.
+Populate each bundle with real data before submitting verification evidence; placeholder files below describe the expectations. Scenario helper scripts (issue #275) and artifact export utilities (issue #276) will automate these steps once they land; until then, follow the commands noted in each scenario README.


### PR DESCRIPTION
## Summary
- add docs/demo/APOLLO_LLM_ONLY.md describing how to run the Apollo webapp against local Sophia/Hermes using the shared SDKs and Hermes `/llm` endpoint (issue #273)
- includes prerequisites, env setup, and artifact capture guidance for logs/benchmarks/browser_llm

## Testing
- docs only
