### PR TITLE
[infra] Add workspace Copilot instructions and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+Issue template for Project LOGOS
+Follow the workspace guidance in `logos/.github/copilot-instructions.md` when filing issues.
+-->
+
+# Title: [COMPONENT] short-summary
+
+## Description
+Briefly describe the problem or feature (1-3 sentences). Explain *why* this change is needed.
+
+## Reproduction / Steps
+If this is a bug, list steps to reproduce. Include commands and minimal data required.
+
+1. Run `...`
+2. Observe `...`
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What happened instead.
+
+## Proposed Change
+Short plan / implementation notes (high level). Include files or modules you expect to modify.
+
+## Acceptance Criteria (tests / checks)
+- [ ] Unit tests added or updated
+- [ ] Integration/E2E tests added (if applicable)
+- [ ] Documentation updated (README, `docs/`, or API spec)
+
+## Environment
+- OS:
+- Python / Node / Docker versions:
+- Relevant env vars or config files (e.g., `config.yaml`, `.env`):
+
+## Related Artifacts
+- Related issue(s):
+- Related PR(s):
+- Spec / ADR references (paths under `logos/docs/`):
+
+## Suggested Labels (maintainers):
+- `area/<component>` (e.g., `area/apollo`)
+- `type/<type>` (e.g., `type/bug`, `type/feature`)
+- `priority/<level>` (e.g., `priority/high`)
+- `status/todo`
+
+## Assignee (optional)
+Assign someone or leave blank for triage.
+
+<!--
+Tip: use the PR template when opening a PR to implement this issue and include `Closes #<issue-number>` in the PR description.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!--
+Pull Request template for Project LOGOS
+Ensure the PR references its issue (use `Closes #<issue-number>` when ready to close).
+-->
+
+# PR Title
+[area] Short summary (#<issue>)
+
+## Summary
+Brief description of the change and why it is needed. Keep it short and focused.
+
+## Related Issue
+Closes #<issue-number>
+Or: See #<issue-number> (explain partial coverage)
+
+## Changes
+- Files / modules changed:
+  - `path/to/file.py`
+  - `webapp/src/components/MyPanel.tsx`
+
+## How to run / test locally
+Include exact commands and environment setup (copyable):
+
+```bash
+# From repo root
+pip install -e ".[dev]"
+cd webapp && npm install
+# Start mock webapp
+cd webapp && npm run dev:mock
+# Run Python tests
+pytest
+```
+
+## Checklist (required)
+- [ ] Linked the related issue (`Closes #<n>` or `See #<n>`) 
+- [ ] Tests added or updated
+- [ ] Linting/formatting run (`black`/`ruff`; `npm run lint` for webapp)
+- [ ] Type checks (Python `mypy`/TS `npm run type-check`) as applicable
+- [ ] Documentation updated (README, `docs/`, or OpenAPI spec)
+- [ ] CI is passing
+
+## Reviewers / Code owners
+Please request at least one reviewer from the relevant area (use `CODEOWNERS` if present).
+
+## Notes
+Any additional notes for reviewers, rationale, or things to watch for.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,45 @@ The LOGOS ecosystem consists of five components (all in separate repositories):
 4. **Apollo** (`c-daly/apollo`) - Thin client UI and command layer
 5. **LOGOS** (this repo) - Foundry and canonical source of truth
 
+## Workspace GitHub, Tickets, and Pull Request Rules
+
+The LOGOS ecosystem contains multiple repositories (`logos/`, `apollo/`, `sophia/`, `hermes/`, `talos/`). Use this section for cross-repo GitHub workflows, ticketing, and PR expectations.
+
+1) GitHub / Authentication issues
+- When a user reports auth problems, request: GitHub username, 2FA status, full error text or screenshot, repo URL, and whether they're using HTTPS or SSH.
+- Quick fixes:
+	- HTTPS: ensure Personal Access Token (PAT) has `repo` scope and is not expired; recommend credential helpers instead of embedding PATs in remotes.
+	- SSH: run `ssh -T git@github.com` and verify the public key is present on the user's GitHub account.
+	- CI secrets: confirm repository `Settings -> Secrets` contain the required keys and organization-level secrets are not blocked.
+- When escalating, include the exact git command used, timestamp, full error text, user account, and CI run URL if applicable.
+
+2) Issues / Tickets
+- Use the issue template or include these fields: Title (`[COMPONENT] short-summary`), Description, Reproduction steps, Expected vs Actual behavior, Proposed change, Acceptance criteria (testable), Environment/versions, Related artifacts (PRs, ADRs), and Assignee.
+
+3) Labels & status conventions
+- Minimal labels for each issue: `area/<component>`, `type/<type>`, `priority/<level>`, `status/<state>` (one of `status/todo`, `status/in-progress`, `status/in-review`, `status/done`).
+- Update `status/*` labels when moving project-board columns; do not rely on comments alone.
+
+4) Branches, commits, and PRs
+- Branch pattern: `{kind}/{issue-number}-{short-kebab}` (e.g. `feature/1234-llm-chat-with-dashboard`).
+- Commits: reference issue number when applicable (e.g., `Add dashboard chat panel (#1234)`).
+- PRs must reference the issue they resolve (use `Closes #<issue-number>`). PR descriptions should include summary, files changed, test steps, screenshots/logs, and an acceptance checklist mapping to the issue.
+
+5) Review & merge
+- Ensure CI passes (tests, lint, OpenAPI validation) before merging. If CI is flaky, link the workflow run and comment before force-merging.
+- Prefer squash merges and include the issue number in the final commit message; for large changes use descriptive merge commits.
+
+6) Project board & automation
+- Use the workspace Project Board per `.github/PROJECT_BOARD_SETUP.md`. Move issues between columns and keep `status/*` labels updated.
+- Use `logos/logos-generate-issues` or `.github/scripts/generate_issues.py` to create batched issues; reference generated issue IDs in PRs.
+
+Examples:
+- Good issue title: `[apollo] Add mock fixture for chat panel (#1234)`
+- Good PR checklist:
+	- Closes #1234
+	- Adds `webapp/src/fixtures/chat-fixture.ts`
+	- Manual test: `cd webapp && npm run dev:mock` and open `http://localhost:5173`
+
 ## General Guidelines
 
 ### Working with HCG Ontology

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,19 @@ For feature requests or enhancements:
 - Address any requested changes
 - Once approved, a maintainer will merge your PR
 
+### Issue & PR Templates (enforced)
+
+This repository provides templates to standardize issue reports and pull requests. Use them to ensure fast triage and smoother reviews.
+
+- Issue template: `logos/.github/ISSUE_TEMPLATE.md` — includes sections for a short, bracketed title (`[COMPONENT] short-summary`), reproduction steps, proposed change, acceptance criteria, environment, and suggested labels.
+- PR template: `logos/.github/PULL_REQUEST_TEMPLATE.md` — includes a required link to the related issue (use `Closes #<issue-number>` when the PR resolves it), a checklist for tests/lint/docs, and exact commands to run locally.
+
+Examples:
+- Issue title: `[apollo] Add mock fixture for chat panel (#1234)`
+- PR description: include `Closes #1234`, a short summary, files changed list, and a `How to run / test locally` section with copyable commands.
+
+Maintainers will expect the checklist in the PR template to be completed before merging. Use the workspace `logos/.github/copilot-instructions.md` for full GitHub/ticketing rules (labels, branch naming, status labels, etc.).
+
 ## Coding Standards
 
 ### Python Code


### PR DESCRIPTION
## Summary
This PR adds workspace-wide Copilot instructions, GitHub issue/PR templates, and updates the contributor guide to enforce consistent ticket and PR workflows across the LOGOS ecosystem.

## Related Issue
This work standardizes GitHub workflows and ticketing. No specific issue tracked (infra improvement).

## Changes
- Added `.github/copilot-instructions.md` with workspace-level GitHub/ticket/PR/auth guidance
- Added `.github/ISSUE_TEMPLATE.md` to enforce issue structure and required fields
- Added `.github/PULL_REQUEST_TEMPLATE.md` to enforce PR checklist and issue linking
- Updated `CONTRIBUTING.md` to reference templates and provide examples

## How to run / test locally
No runtime changes. Review the new template files:
```bash
cat .github/ISSUE_TEMPLATE.md
cat .github/PULL_REQUEST_TEMPLATE.md
cat .github/copilot-instructions.md
```

Test by creating a new issue or PR and verify the templates auto-populate.

## Checklist (required)
- [x] Linked the related issue (N/A - infra improvement)
- [x] Tests added or updated (N/A - templates only)
- [x] Linting/formatting run (markdown files)
- [x] Type checks (N/A)
- [x] Documentation updated (CONTRIBUTING.md updated)
- [ ] CI is passing (will confirm after PR creation)

## Reviewers / Code owners
Please review: maintainers with GitHub admin access

## Notes
These templates will auto-populate when creating new issues/PRs. The workspace Copilot instructions provide AI coding agents with consistent guidance across all LOGOS repos.