### PR TITLE
ci: adopt reusable workflow in logos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,40 +12,18 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Run pytest
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12']
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest pytest-cov ruff mypy httpx
-      
-      - name: Run linting with ruff
-        run: |
-          ruff check .
-      
-      - name: Run tests with pytest
-        run: |
-          pytest -v --cov --cov-report=term-missing --cov-report=xml
-      
-      - name: Upload coverage to artifacts
-        uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.11'
-        with:
-          name: coverage-report
-          path: coverage.xml
-          retention-days: 30
+  standard:
+    uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@ci-standard-workflow-294
+    with:
+      python_versions: '["3.10","3.11","3.12"]'
+      python_install_command: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install pytest pytest-cov ruff mypy httpx
+      python_lint_paths: '.'
+      run_black: false
+      pytest_command: 'pytest -v --cov --cov-report=term-missing --cov-report=xml'
+      coverage_python_version: '3.11'
+      run_mypy: false
+      upload_coverage: false
+    secrets: inherit


### PR DESCRIPTION
## Summary
- convert .github/workflows/test.yml to call reusable-standard-ci so the repo shares the same lint/test matrix
- keep the existing Python 3.10-3.12 matrix and dev dependency install script, and reuse the original pytest invocation
- disable Codecov upload/mypy for now to preserve current behavior; we can enable them once the repo is ready

## Testing
- workflow only

Closes #295.