### PR TITLE
Parameterize Docker Compose Ports

### DIFF
--- a/infra/docker-compose.hcg.dev.yml
+++ b/infra/docker-compose.hcg.dev.yml
@@ -7,8 +7,8 @@ services:
     image: neo4j:5.13.0
     container_name: logos-hcg-neo4j
     ports:
-      - "7474:7474"  # HTTP
-      - "7687:7687"  # Bolt
+      - "${NEO4J_HTTP_PORT:-7474}:7474"  # HTTP
+      - "${NEO4J_BOLT_PORT:-7687}:7687"  # Bolt
     environment:
       - NEO4J_AUTH=neo4j/logosdev
       - NEO4JLABS_PLUGINS=["apoc"]
@@ -28,8 +28,8 @@ services:
     image: milvusdb/milvus:v2.3.3
     container_name: logos-hcg-milvus
     ports:
-      - "19530:19530"  # gRPC
-      - "9091:9091"    # Metrics
+      - "${MILVUS_PORT:-19530}:19530"  # gRPC
+      - "${MILVUS_METRICS_PORT:-9091}:9091"    # Metrics
     environment:
       - ETCD_USE_EMBED=true
       - COMMON_STORAGETYPE=local
@@ -46,7 +46,7 @@ services:
       dockerfile: infra/Dockerfile.shacl-validation
     container_name: logos-shacl-validation
     ports:
-      - "8081:8081"  # SHACL Validation API
+      - "${SHACL_API_PORT:-8081}:8081"  # SHACL Validation API
     volumes:
       - ../ontology:/app/ontology:ro
     networks:


### PR DESCRIPTION
Updates docker-compose.hcg.dev.yml to use environment variables for ports, allowing centralized configuration. Fixes #301.