### PR TITLE
docs: Add Phase 3 spec and update reflection roadmap

### DIFF
--- a/docs/architecture/LOGOS_SPEC_FLEXIBLE.md
+++ b/docs/architecture/LOGOS_SPEC_FLEXIBLE.md
@@ -253,12 +253,23 @@ Focus on improving reasoning/execution while staying hardware-optional:
 - Deliver extensive diagnostics, visualization, and explainability tooling (graph inspectors, plan timelines, causal traces, capability telemetry) available from both CLI and browser experiences.
 - **Success criteria (target)**: Sophia plans against live Talos capability lists, executor reports telemetry into the HCG, embeddings/Milvus health checks run in CI, and at least one alternative Apollo surface demonstrates the loop.
 
-### 7.3 Phase 3 — Learning & Optional Embodiment
-- Introduce episodic memory in the HCG, plan learning from execution history.
-- Layer Level 2 probabilistic validation.
-- Demo at least one alternative embodiment (e.g., desk touchscreen, drone) without contract changes.
-- Explore multi-agent coordination primitives across Talos capabilities.
-- **Success criteria (target)**: Agent improves plan quality using experience, probabilistic validation augments SHACL, and heterogeneous Talos capabilities coordinate without contract changes.
+### 7.3 Phase 3 — Learning & Memory Systems
+- Implement short-term memory (session-scoped ephemeral CWMState with Redis/in-memory storage, promotion policies)
+- Event-driven reflection system (error, user correction, session boundary triggers) creating selective diary entries
+- Replace per-turn observations with meaningful, curated persona history based on impact criteria
+- Introduce episodic memory in the HCG, enable plan learning from execution history
+- Layer Level 2 probabilistic validation to complement SHACL with uncertainty reasoning
+- Demo at least one alternative embodiment (e.g., desk touchscreen, drone) without contract changes
+- Explore multi-agent coordination primitives across Talos capabilities
+- **Success criteria**: Short-term memory serves all subsystems, reflection generates meaningful insights, diary relevance improved, agent demonstrates learning from episodes, probabilistic validation augments SHACL, heterogeneous Talos capabilities coordinate without contract changes
+
+### 7.4 Phase 4 — Operational Autonomy & Advanced Reflection
+- **Meta-reflection**: Periodic aggregate analysis across diary entries to identify systemic patterns (e.g., "10 reflections about verbosity indicates communication style issue")
+- **Personality evolution tracking**: Long-term monitoring of agent behavior changes, tone adaptation, preference drift
+- **Deep planner integration**: Reflection-driven strategy adjustment, dynamic capability confidence weighting, risk assessment based on emotional state
+- **Continuous learning with safety gates**: Production deployment patterns with rollback, A/B testing, human-in-the-loop validation
+- **Observability enhancements**: Real-time reflection quality metrics, memory usage dashboards, learning curve visualization
+- **Success criteria**: Meta-reflections drive systemic improvements, personality evolution tracked and explainable, planner adapts strategy based on reflection history, production-safe continuous learning demonstrated
 
 ---
 

--- a/docs/architecture/PHASE3_SPEC.md
+++ b/docs/architecture/PHASE3_SPEC.md
@@ -1,0 +1,255 @@
+# Phase 3 Specification — Learning & Memory Systems
+
+Phase 3 builds on the Phase 2 foundation to deliver adaptive, learning-capable agent behavior through memory systems, event-driven reflection, and episodic learning. This phase transforms LOGOS from a reactive system into one that learns from experience and develops a persistent personality.
+
+## Goals
+1. **Short-term Memory** — Implement session-scoped ephemeral memory for conversational context and transient reasoning
+2. **Event-driven Reflection** — Create intelligent, selective diary entries based on significant events rather than every interaction
+3. **Selective Diary Entries** — Replace per-turn observation logging with meaningful, curated persona history
+4. **Episodic Memory** — Enable the agent to learn from execution history and improve plan quality over time
+5. **Probabilistic Validation** — Layer Level 2 validation to complement SHACL constraints with uncertainty reasoning
+
+## Milestones
+
+### P3-M1: Short-term Memory Infrastructure
+
+**Objective**: Implement session-scoped ephemeral memory that serves as working context for all agent subsystems.
+
+**Deliverables**:
+- **Storage backend**: Redis or in-memory store with TTL support for ephemeral `CWMState` entries
+- **API endpoints**: 
+  - `POST /api/memory/ephemeral` - Create ephemeral entry
+  - `GET /api/memory/ephemeral` - Query recent entries (by type, time window, session)
+  - `DELETE /api/memory/ephemeral/{id}` - Explicit deletion
+  - `POST /api/memory/promote/{id}` - Promote ephemeral entry to persistent HCG
+- **Session management**: Track session lifecycle, automatic expiration, cleanup
+- **CWMState envelope**: All ephemeral entries use `status="ephemeral"` in unified contract
+- **Promotion policies**: Configurable rules for what gets persisted (logged for auditability)
+
+**Use cases**:
+- Conversational context (current topic, pending clarifications, in-progress reasoning)
+- Recent perceptual observations (last N frames, sensor readings)
+- Error tracking (retry attempts, backoff state)
+- User preferences (session-specific settings, temporary constraints)
+- Capability execution state (multi-step operation progress)
+- Curiosity flags (unknowns to investigate, ambiguities to resolve)
+
+**Success criteria**:
+- Short-term memory API functional and integrated
+- At least 3 subsystems (planner, reflection, LLM chat) consume ephemeral memory
+- Promotion policies demonstrated (manual and automatic)
+- Session cleanup verified (no memory leaks)
+
+---
+
+### P3-M2: Event-driven Reflection System
+
+**Objective**: Implement intelligent reflection triggers that create meaningful diary entries based on significant events, not time intervals.
+
+**Deliverables**:
+- **Reflection triggers** (event-based hooks):
+  - `error` - Plan execution failures, validation errors, capability failures
+  - `user_request` - Explicit instructions to change behavior, tone, or approach
+  - `correction` - User corrects agent's understanding or actions
+  - `session_boundary` - Conversation start (load context) / end (consolidate learnings)
+  - `milestone` - Goal completion, significant progress, new capability
+- **LLM-powered reflection prompts**: Analyze short-term memory and recent context to generate introspective reflections
+- **Reflection entry creation**: Create `PersonaEntry` with `entry_type="reflection"` and appropriate `trigger` value
+- **Context analysis**: Reflection system reads:
+  - Short-term memory (recent conversation, errors, user signals)
+  - Recent `PersonaEntry` nodes (prior reflections, observations)
+  - Plan/process outcomes (success/failure patterns)
+- **EmotionState generation**: Reflection output includes emotional assessment (confidence, caution, sentiment) stored as `EmotionState` nodes
+
+**Reflection content examples**:
+- "User corrected my assumption about X three times - need to ask clarifying questions earlier"
+- "Navigation tasks succeeding consistently - increasing confidence in spatial reasoning"
+- "Verbose explanations triggered frustration - adjusting default communication style"
+- "Missed obvious validation step leading to error - adding to standard procedure"
+
+**Success criteria**:
+- Reflections triggered by events, not periodic timers
+- Reflection quality assessed by stakeholders (meaningful insights)
+- Planner demonstrates behavior adjustment based on reflection content
+- EmotionState nodes influence persona tone in LLM responses
+
+---
+
+### P3-M3: Selective Diary Entry Creation
+
+**Objective**: Replace automatic per-turn observations with selective, meaningful diary entries based on impact criteria.
+
+**Deliverables**:
+- **Entry creation criteria**:
+  - **Impact**: Does this change how agent should behave going forward?
+  - **Reusability**: Will this context matter in future sessions?
+  - **Learning value**: Is there a lesson or pattern to extract?
+  - **User signal**: Did user explicitly indicate importance?
+- **Automatic triggers for observations**:
+  - Context shift (topic/domain change, new user information, environment change)
+  - Novel information (user preferences, constraints, facts not in HCG)
+  - Ambiguity resolution (clarifications that change understanding)
+  - Significant interactions (exchanges that materially advance goals)
+- **Short-term memory promotion**: Criteria for elevating ephemeral entries to persistent diary
+- **Diary query optimization**: Index and query patterns for retrieving relevant historical context
+- **Backward compatibility**: Existing observation-heavy workflows can opt into new selective behavior
+
+**What does NOT create diary entries**:
+- Individual chat messages (stay in short-term memory)
+- Temporary state (current discussion topic)
+- Pending clarifications
+- In-progress reasoning chains
+
+**Success criteria**:
+- Diary entry volume reduced significantly (measured against Phase 2 baseline)
+- Diary query relevance improved (stakeholder assessment)
+- Short-term memory serves as working context without diary pollution
+- Critical information still captured (no loss of important context)
+
+---
+
+### P3-M4: Episodic Memory & Learning
+
+**Objective**: Enable the agent to learn from execution history and improve plan quality over time.
+
+**Deliverables**:
+- **Episodic storage**: HCG schema for recording execution episodes (plan → actions → outcomes)
+- **Episode indexing**: Link episodes to goals, capabilities, contexts for retrieval
+- **Learning from outcomes**: Analyze success/failure patterns across episodes
+- **Plan quality improvement**: Planner queries relevant episodes before generating new plans
+- **Probabilistic validation (Level 2)**: Augment SHACL with uncertainty-based validation using learned patterns
+- **Capability confidence**: Track per-capability success rates, adjust planning accordingly
+- **Context-sensitive learning**: Different strategies for different domains/users
+
+**Episode structure**:
+```
+Episode {
+  id, timestamp, goal, plan_id,
+  actions: [{ capability, params, result, confidence }],
+  outcome: { success, failure_reason, duration },
+  context: { user, environment, constraints },
+  reflections: [related PersonaEntry IDs],
+  learned: { patterns, adjustments, recommendations }
+}
+```
+
+**Success criteria**:
+- Plan quality measurably improves over repeated similar goals
+- Probabilistic validation catches issues SHACL misses
+- Capability selection adapts based on historical success rates
+- Agent demonstrates learning without explicit retraining
+
+---
+
+## Implementation Notes
+
+### Short-term Memory Architecture
+- **Storage**: Redis with session-scoped keyspaces (`session:{id}:memory:*`)
+- **TTL**: Configurable per entry type (default: 1 hour for conversation, 15 minutes for perception)
+- **Promotion**: Manual API calls or automatic policy engine (rule-based or LLM-assisted)
+- **Integration**: All Phase 2 services (Sophia, Hermes, Apollo) consume memory API
+
+### Reflection System Architecture
+- **Trigger detection**: Event handlers in Sophia (plan execution), Apollo (user interaction), CWM-E (error monitoring)
+- **Reflection LLM**: Separate prompt template for introspection, distinct from chat/planning prompts
+- **Context window**: Last N ephemeral entries + recent diary entries + current plan state
+- **Output format**: Structured reflection (trigger, insight, recommendation, confidence) → PersonaEntry
+
+### Diary Entry Decision Logic
+- **Decision point**: Before creating any PersonaEntry, evaluate impact criteria
+- **LLM-assisted**: Use small classifier or prompt to determine "meaningful Y/N"
+- **Override**: Manual diary commands always create entries (stakeholder discretion)
+- **Audit trail**: Log all "rejected" entry attempts for tuning criteria
+
+### Episodic Learning Flow
+1. Plan execution completes (success or failure)
+2. Create Episode record with full trace
+3. Link to related PersonaEntry reflections
+4. Index by goal type, capabilities, context
+5. Future plans query similar episodes
+6. Adjust confidence, strategy, capability selection
+
+---
+
+## Dependencies
+
+- **Phase 2 completion**: Sophia/Hermes services, Apollo surfaces, PersonaEntry with `trigger` field, basic CWM-E
+- **Redis instance**: For ephemeral memory (or alternative key-value store)
+- **LLM access**: For reflection prompts and decision logic
+- **Neo4j schema updates**: Episode storage, memory indexing
+- **Observability**: Track memory usage, promotion rates, reflection quality
+
+---
+
+## Verification & Success Criteria
+
+### M1 - Short-term Memory
+- [ ] Redis backend operational with TTL
+- [ ] API endpoints functional (create, query, promote, delete)
+- [ ] Session management with automatic cleanup
+- [ ] 3+ subsystems consuming memory API
+- [ ] Promotion policies demonstrated
+- [ ] Load test: 100 concurrent sessions, no memory leaks
+
+### M2 - Event-driven Reflection
+- [ ] 5+ trigger types implemented (error, user_request, correction, session_boundary, milestone)
+- [ ] LLM reflection prompts generate meaningful insights (stakeholder review)
+- [ ] Reflections create PersonaEntry nodes correctly
+- [ ] EmotionState nodes linked to reflections
+- [ ] Planner demonstrates behavior change from reflection content
+- [ ] No periodic reflection jobs (all event-driven)
+
+### M3 - Selective Diary Entries
+- [ ] Impact criteria documented and implemented
+- [ ] Per-turn observation creation disabled by default
+- [ ] Diary entry volume reduced >70% vs Phase 2
+- [ ] Stakeholder assessment: diary relevance improved
+- [ ] Short-term memory serves working context
+- [ ] Critical information capture validated (no regressions)
+
+### M4 - Episodic Learning
+- [ ] Episode schema in HCG, CRUD operations functional
+- [ ] Episode indexing by goal/capability/context
+- [ ] Planner queries episodes before plan generation
+- [ ] Demonstrated improvement: 2nd attempt at repeated goal succeeds faster
+- [ ] Probabilistic validation catches uncertain plans
+- [ ] Capability confidence scores adjust based on outcomes
+
+---
+
+## Phase 3 Roadmap
+
+**Timeline**: Estimated 8-12 weeks
+
+| Milestone | Duration | Dependencies |
+|-----------|----------|--------------|
+| P3-M1 (Short-term memory) | 2-3 weeks | Phase 2 complete |
+| P3-M2 (Event-driven reflection) | 3-4 weeks | P3-M1 complete |
+| P3-M3 (Selective diary) | 2-3 weeks | P3-M1, P3-M2 complete |
+| P3-M4 (Episodic learning) | 3-4 weeks | P3-M3 complete |
+
+**Parallel work opportunities**:
+- Redis setup and API can proceed independently
+- LLM reflection prompt development can start early
+- Episode schema design can overlap with M3
+
+---
+
+## Future Considerations (Phase 4+)
+
+Phase 3 provides the foundation. Advanced features for later phases:
+
+- **Meta-reflection**: Periodic aggregate analysis across many diary entries (pattern detection at scale)
+- **Personality evolution tracking**: Long-term changes in agent behavior, tone, preferences
+- **Deep planner integration**: Reflection-driven strategy adjustment, dynamic capability weighting
+- **Multi-agent memory sharing**: Selective knowledge transfer between LOGOS instances
+- **Memory compression**: Summarize/consolidate old episodes to manage growth
+
+---
+
+## References
+
+- `PHASE2_SPEC.md` - PersonaEntry schema, CWM-E foundations
+- `LOGOS_SPEC_FLEXIBLE.md` - Short-term memory conceptual architecture
+- `apollo/docs/PERSONA_DIARY.md` - Diary API and usage patterns
+- `docs/operations/PHASE2_VERIFY.md` - Phase 2 completion criteria

--- a/docs/operations/PHASE2_VERIFY.md
+++ b/docs/operations/PHASE2_VERIFY.md
@@ -691,32 +691,43 @@ CWM-G (JEPA) simulation is fully functional with CPU-friendly mode operational. 
 - [x] ✅ WebSocket integration for real-time updates
 - [x] ✅ Documented in `apollo/docs/PERSONA_DIARY.md`
 
-#### 4.3 CWM-E Reflection Job + EmotionState Nodes
+#### 4.3 CWM-E Reflection Infrastructure + EmotionState Nodes
 
-**Status:** ⚠️ **PARTIALLY COMPLETE** (Module Exists, Not Integrated)
+**Status:** ⚠️ **FOUNDATIONS IN PLACE** (Infrastructure Ready, Full System Phase 3)
 
-**Implementation:**
-- EmotionState module exists: `logos/logos_cwm_e/`
-- EmotionState nodes can be created and queried
-- API endpoints available for manual reflection
-- Persona sentiment tracking via PersonaEntry nodes
+**Phase 2 Scope (Foundations):**
+- EmotionState and PersonaEntry schemas with `trigger` field
+- API endpoints for creating/querying emotions and diary entries
+- Basic reflection infrastructure (hooks, data models)
+- PersonaEntry sentiment tracking
 
 **Implementation Evidence:**
 - [x] ✅ CWM-E module: `logos/logos_cwm_e/reflection.py`, `logos/logos_cwm_e/api.py`
 - [x] ✅ EmotionState schema defined
-- [x] ✅ API endpoints for creating/querying emotions
+- [x] ✅ PersonaEntry schema includes optional `trigger` field (free-form text)
+- [x] ✅ API endpoints for creating/querying emotions and diary entries
 - [x] ✅ PersonaEntry sentiment field tracks emotional tone
+- [x] ✅ Apollo CLI accepts `--trigger` parameter for diary entries
 - [x] ✅ Apollo chat and diary consume persona context
-- [ ] ❌ **Periodic reflection job NOT running** - spec requires "FastAPI background task (or separate worker) runs every N minutes"
-- [ ] ❌ **Planner/executor NOT consuming EmotionState** - spec requires "Planner/executor must read the latest emotion nodes to adjust strategy"
-- [ ] ❌ **No automatic emotion generation** - emotions must be created manually via API
+- [ ] ⚠️ **Event-driven reflection NOT implemented** - Phase 3 feature
+- [ ] ⚠️ **Planner/executor NOT consuming EmotionState** - Phase 3 integration
+- [ ] ⚠️ **Selective diary entry creation NOT implemented** - Phase 3 feature
 
-**Gap Analysis:**
-The spec explicitly states:
-- "Reflection job: FastAPI background task (or separate worker) runs every N minutes"
-- "Planner/executor must read the latest emotion nodes to adjust strategy (e.g., avoid risky capability when `caution` high)"
+**Clarification:**
+Original Phase 2 spec mentioned "FastAPI background task runs every N minutes" but architectural discussion revealed event-driven reflection is more appropriate. Phase 2 provides the **data model and infrastructure foundations**:
+- `trigger` field enables categorization of reflections (error, user_request, self_model, meta, etc.)
+- PersonaEntry schema supports `entry_type="reflection"` 
+- EmotionState nodes can be created and linked
 
-Current implementation has the infrastructure but NOT the automation or integration.
+**Phase 3 will deliver:**
+- Event-driven reflection triggers (errors, user corrections, session boundaries)
+- LLM-powered reflection prompts analyzing context
+- Selective diary entry creation (not every chat turn)
+- Short-term memory system for ephemeral context
+- Planner integration consuming EmotionState for strategy adjustment
+
+**Phase 2 Achievement:**
+Infrastructure ready for Phase 3 reflection system - data models, API endpoints, and storage layer complete.
 
 #### 4.4 Demo Capture Script
 


### PR DESCRIPTION
Creates comprehensive Phase 3 specification for memory and reflection systems with 4 milestones: short-term memory, event-driven reflection, selective diary entries, and episodic learning. Updates Phase 2 spec to clarify reflection foundations and Phase 4 roadmap for meta-reflection. Companion to apollo PR c-daly/apollo#81