### PR TITLE
[logos] Shared test stack template fixes (#354)

### DIFF
--- a/docs/operations/PHASE2_VERIFY.md
+++ b/docs/operations/PHASE2_VERIFY.md
@@ -111,7 +111,7 @@ Phase 2 extends the LOGOS ecosystem with:
 - All endpoints operational: `/plan`, `/state`, `/simulate`, `/health`
 - Token-based authentication in `sophia/src/sophia/api/auth.py`
 - Docker configurations: `sophia/Dockerfile`, `sophia/docker-compose.yml`
-- Deployment summary: `sophia/IMPLEMENTATION_SUMMARY.md`
+- Deployment summary: `sophia/SOPHIA_TEST_GUIDE.md`
 
 #### 1.2 Hermes Service Running
 


### PR DESCRIPTION
# Summary
- fix `deep_format` so template keys (e.g. `{volume_prefix}_neo4j_data`) are rendered before writing docker-compose files
- rerun the generator to ensure staged outputs and version hashes stay in sync
- point the Phase 2 verification doc at the new `sophia/SOPHIA_TEST_GUIDE.md` deployment summary

# Testing
- `poetry run ruff check infra/scripts/render_test_stacks.py`
- `poetry run python infra/scripts/render_test_stacks.py --repo logos`
- `poetry run python infra/scripts/render_test_stacks.py`
- `poetry run python infra/scripts/render_test_stacks.py --check`

Closes #354