### PR TITLE
Follow-up to PR #361: stack env helper

### DIFF
--- a/docs/operations/TESTING.md
+++ b/docs/operations/TESTING.md
@@ -83,6 +83,11 @@ cd ../..
 SOPHIA_API_KEY=test-token-12345 RUN_P2_E2E=1 poetry run pytest tests/phase2/test_phase2_end_to_end.py -v
 ```
 
+> **Tip:** `tests/e2e/run_e2e.sh` wraps the same stack definition, sources the
+> generated `.env.test`, and exports the container identifiers required by the
+> integration tests. Prefer the helper when you need the Phase 1 milestone
+> suites and Phase 2 flows to share a single stack.
+
 ---
 
 ## CI/CD Requirements
@@ -206,25 +211,48 @@ RUN_M4_E2E=1 pytest tests/phase1/test_m4_end_to_end.py
 
 ## Environment Variables
 
-```bash
-# Enable E2E tests
-RUN_P2_E2E=1
-RUN_M4_E2E=1
+`tests/e2e/stack/logos/.env.test` is the canonical schema for the shared test
+stack. The file is generated via `poetry run render-test-stacks --repo logos`
+and is automatically sourced by `tests/e2e/run_e2e.sh`. Copy or export the
+variables below when running tests directly via `pytest`.
 
-# Service URLs
+### Test Toggles
+
+```bash
+RUN_P2_E2E=1      # Enable Phase 2 end-to-end suite
+RUN_M4_E2E=1      # Enable Phase 1 Milestone 4 suite
+```
+
+### Service URLs
+
+```bash
 SOPHIA_URL=http://localhost:8001
 HERMES_URL=http://localhost:8002
 APOLLO_URL=http://localhost:8003
+```
 
-# Database connections
-NEO4J_URI=bolt://localhost:7687
+### Neo4j Configuration
+
+```bash
+NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=logosdev
-
-# Milvus
-MILVUS_HOST=localhost
-MILVUS_PORT=19530
+NEO4J_CONTAINER=logos-phase2-test-neo4j   # Optional override when reusing an existing stack
 ```
+
+### Milvus Configuration
+
+```bash
+MILVUS_HOST=milvus
+MILVUS_PORT=19530
+MILVUS_HEALTHCHECK=http://milvus:9091/healthz
+MILVUS_CONTAINER=logos-phase2-test-milvus
+```
+
+> Integration tests auto-detect the running container names via
+> `tests/utils/container_utils.py`, but defining `NEO4J_CONTAINER` and
+> `MILVUS_CONTAINER` keeps the behaviour deterministic across CI jobs and local
+> developer stacks.
 
 ---
 

--- a/infra/test_stack/repos.yaml
+++ b/infra/test_stack/repos.yaml
@@ -27,6 +27,8 @@ defaults:
     MILVUS_HOST: milvus
     MILVUS_PORT: "{milvus_grpc_port}"
     MILVUS_HEALTHCHECK: "http://milvus:{milvus_metrics_port}/healthz"
+    NEO4J_CONTAINER: "{service_prefix}-neo4j"
+    MILVUS_CONTAINER: "{service_prefix}-milvus"
 repos:
   logos:
     path: .

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -19,14 +19,15 @@ tests/e2e/
 ## Quick Start
 
 ```bash
-# Start the test stack
+# Full cycle: start stack, seed data, run pytest, and tear down
+./tests/e2e/run_e2e.sh
+# (equivalent to ./tests/e2e/run_e2e.sh test)
+
+# Start the test stack only
 ./tests/e2e/run_e2e.sh up
 
 # Seed test data (load ontology, init Milvus collections)
 ./tests/e2e/run_e2e.sh seed
-
-# Run tests
-./tests/e2e/run_e2e.sh test
 
 # Check status
 ./tests/e2e/run_e2e.sh status
@@ -37,6 +38,28 @@ tests/e2e/
 # Full cleanup (including volumes)
 ./tests/e2e/run_e2e.sh clean
 ```
+
+## Environment Variables
+
+`tests/e2e/stack/logos/.env.test` is the canonical schema used by Docker Compose,
+helper scripts, and downstream repositories. The `run_e2e.sh` helper sources this
+file automatically so the variables are available to `pytest`, seed scripts, and
+any custom commands.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `NEO4J_URI` | Bolt endpoint exposed by the stack | `bolt://neo4j:7687` |
+| `NEO4J_USER` | Neo4j username | `neo4j` |
+| `NEO4J_PASSWORD` | Neo4j password | `logosdev` |
+| `NEO4J_CONTAINER` | Neo4j docker container name | `logos-phase2-test-neo4j` |
+| `MILVUS_HOST` | Milvus hostname inside the stack | `milvus` |
+| `MILVUS_PORT` | Milvus gRPC port | `19530` |
+| `MILVUS_HEALTHCHECK` | Milvus health endpoint | `http://milvus:9091/healthz` |
+| `MILVUS_CONTAINER` | Milvus docker container name | `logos-phase2-test-milvus` |
+
+> **Tip:** The integration tests also auto-detect the running container names. If
+you prefer to keep the legacy dev stack running (`logos-hcg-neo4j`), set the
+`NEO4J_CONTAINER` environment variable before invoking `pytest`.
 
 ## Regenerating Stack Files
 

--- a/tests/e2e/stack/logos/.env.test
+++ b/tests/e2e/stack/logos/.env.test
@@ -4,3 +4,5 @@ MILVUS_PORT=19530
 NEO4J_PASSWORD=logosdev
 NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
+NEO4J_CONTAINER=logos-phase2-test-neo4j
+MILVUS_CONTAINER=logos-phase2-test-milvus

--- a/tests/phase1/test_m1_neo4j_crud.py
+++ b/tests/phase1/test_m1_neo4j_crud.py
@@ -20,11 +20,13 @@ import pytest
 from neo4j import GraphDatabase
 from neo4j.exceptions import ClientError, ServiceUnavailable
 
+from tests.utils.container_utils import resolve_neo4j_container
+
 # Test configuration
 NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
 NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
 NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "logosdev")
-NEO4J_CONTAINER = os.getenv("NEO4J_CONTAINER", "logos-hcg-neo4j")
+NEO4J_CONTAINER = resolve_neo4j_container()
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 
 

--- a/tests/phase1/test_m4_end_to_end.py
+++ b/tests/phase1/test_m4_end_to_end.py
@@ -19,6 +19,11 @@ from pathlib import Path
 
 import pytest
 
+from tests.utils.container_utils import (
+    resolve_milvus_container,
+    resolve_neo4j_container,
+)
+
 # Try to import planner client for API-based planning
 try:
     from planner_stub.client import PlannerClient
@@ -40,7 +45,8 @@ REPO_ROOT = Path(__file__).parent.parent.parent
 NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
 NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
 NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "logosdev")
-NEO4J_CONTAINER = os.getenv("NEO4J_CONTAINER", "logos-hcg-neo4j")
+NEO4J_CONTAINER = resolve_neo4j_container()
+MILVUS_CONTAINER = resolve_milvus_container()
 
 
 def is_neo4j_available() -> bool:
@@ -76,7 +82,7 @@ def is_milvus_available() -> bool:
             text=True,
             timeout=5,
         )
-        return "logos-hcg-milvus" in result.stdout
+        return MILVUS_CONTAINER in result.stdout
     except Exception:
         return False
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Test utilities for LOGOS."""

--- a/tests/utils/container_utils.py
+++ b/tests/utils/container_utils.py
@@ -1,0 +1,78 @@
+"""Helpers for resolving container names used in integration tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Iterable
+
+
+DEFAULT_NEO4J_CANDIDATES: tuple[str, ...] = (
+    "logos-phase2-test-neo4j",
+    "logos-hcg-neo4j",
+)
+
+DEFAULT_MILVUS_CANDIDATES: tuple[str, ...] = (
+    "logos-phase2-test-milvus",
+    "logos-hcg-milvus",
+)
+
+
+def _docker_container_exists(name: str) -> bool:
+    """Return True if a docker container with the given name exists."""
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"name=^{name}$",
+                "--format",
+                "{{.Names}}",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False
+
+    containers = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    return name in containers
+
+
+def _resolve_container_name(
+    *,
+    env_var: str,
+    candidates: Iterable[str],
+) -> str:
+    env_value = os.getenv(env_var)
+    if env_value:
+        return env_value
+
+    check_candidates = tuple(candidates)
+    for candidate in check_candidates:
+        if _docker_container_exists(candidate):
+            return candidate
+
+    # Fall back to the first candidate if nothing else resolves.
+    return check_candidates[0]
+
+
+def resolve_neo4j_container() -> str:
+    """Resolve the Neo4j docker container name across dev/test stacks."""
+
+    return _resolve_container_name(
+        env_var="NEO4J_CONTAINER",
+        candidates=DEFAULT_NEO4J_CANDIDATES,
+    )
+
+
+def resolve_milvus_container() -> str:
+    """Resolve the Milvus docker container name across dev/test stacks."""
+
+    return _resolve_container_name(
+        env_var="MILVUS_CONTAINER",
+        candidates=DEFAULT_MILVUS_CANDIDATES,
+    )


### PR DESCRIPTION
## Summary
- add shared `tests/utils/container_utils.py` so phase 1 milestone suites are no longer hard-coded to a specific container name
- emit `NEO4J_CONTAINER` / `MILVUS_CONTAINER` in the stack generator and wire the values through `.env.test` + `run_e2e.sh`
- make the default `tests/e2e/run_e2e.sh` behaviour spin up the stack, seed Neo4j/Milvus, run pytest, and tear down before exiting; refresh testing docs accordingly

## Testing
- `poetry run pytest tests/phase1/test_m1_neo4j_crud.py`
- `poetry run pytest tests/phase1/test_m4_end_to_end.py`

Follow-up to #361.