### PR TITLE
Complete test standardization: fix credentials, remove dead code, ensure adoption

### DIFF
--- a/docs/operations/PORT_REFERENCE.md
+++ b/docs/operations/PORT_REFERENCE.md
@@ -1,0 +1,115 @@
+# LOGOS Test Stack Port Reference
+
+**Quick reference for test environment port assignments.**
+
+## Port Map
+
+| Service | logos (default) | apollo | hermes | sophia | talos |
+|---------|----------------|--------|--------|--------|-------|
+| **Neo4j HTTP** | 7474 | 27474 | N/A | 37474 | 47474 |
+| **Neo4j Bolt** | 7687 | 27687 | N/A | 37687 | 47687 |
+| **Milvus gRPC** | 19530 | 29530 | 19530 | 39530 | N/A |
+| **Milvus Metrics** | 9091 | 29091 | 19091 | 39091 | N/A |
+
+## Connection Strings by Repo
+
+### logos (default/dev)
+```bash
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=logosdev
+MILVUS_HOST=milvus
+MILVUS_PORT=19530
+```
+
+### apollo
+```bash
+NEO4J_URI=bolt://neo4j:27687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=logosdev
+MILVUS_HOST=milvus
+MILVUS_PORT=29530
+```
+
+### hermes
+```bash
+# Hermes only uses Milvus
+MILVUS_HOST=milvus
+MILVUS_PORT=19530
+```
+
+### sophia
+```bash
+NEO4J_URI=bolt://neo4j:37687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=logosdev
+MILVUS_HOST=milvus
+MILVUS_PORT=39530
+```
+
+### talos
+```bash
+# Talos only uses Neo4j
+NEO4J_URI=bolt://neo4j:47687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=logosdev
+```
+
+## Container Name Prefixes
+
+- `logos-phase2-test-*` (logos repo)
+- `apollo-test-*` (apollo repo)
+- `hermes-test-*` (hermes repo)
+- `sophia-test-*` (sophia repo)
+- `talos-test-*` (talos repo)
+
+## Finding Your Containers
+
+```bash
+# See all LOGOS test containers
+docker ps --filter "name=test"
+
+# Check specific repo
+docker ps --filter "name=apollo-test"
+```
+
+## Why These Ports?
+
+- **logos**: Standard ports (7xxx, 19xxx) - "home base"
+- **apollo**: 2xxxx range - easy to remember "2=Apollo"
+- **hermes**: Uses logos' Milvus (no Neo4j in tests)
+- **sophia**: 3xxxx range
+- **talos**: 4xxxx range (only Neo4j)
+
+## Common Issues
+
+### Port Already in Use
+```bash
+# Find what's using a port
+lsof -i :7687
+
+# Stop conflicting container
+docker stop $(docker ps -q --filter "name=test")
+```
+
+### Can't Connect to Service
+```bash
+# Check service is running
+docker compose -f tests/e2e/docker-compose.test.apollo.yml ps
+
+# Check health
+docker inspect apollo-test-neo4j | grep -A 10 Health
+```
+
+## Quick Start Commands
+
+```bash
+# Start your repo's test stack
+docker compose -f tests/e2e/docker-compose.test.{REPO}.yml up -d
+
+# Run tests
+poetry run pytest tests/
+
+# Stop stack
+docker compose -f tests/e2e/docker-compose.test.{REPO}.yml down
+```

--- a/docs/operations/TEST_STANDARDIZATION_MIGRATION.md
+++ b/docs/operations/TEST_STANDARDIZATION_MIGRATION.md
@@ -1,0 +1,256 @@
+# Test Standardization Migration Guide
+
+**Status**: In Progress (feature/logos-test-utils branch)  
+**Related Issues**: #326, #358, #363-367  
+**Target Date**: December 2025
+
+## Overview
+
+This migration standardizes test infrastructure across all LOGOS repos to eliminate port conflicts, credential inconsistencies, and fixture duplication.
+
+## What Changed
+
+### 1. Port Assignments (No More Conflicts!)
+
+| Repo   | Neo4j HTTP | Neo4j Bolt | Milvus gRPC | Milvus Metrics |
+|--------|-----------|-----------|-------------|----------------|
+| logos  | 7474      | 7687      | 19530       | 9091          |
+| apollo | 27474     | 27687     | 29530       | 29091         |
+| hermes | N/A       | N/A       | 19530       | 19091         |
+| sophia | 37474     | 37687     | 39530       | 39091         |
+| talos  | 47474     | 47687     | N/A         | N/A           |
+
+**Result**: All repos can run tests simultaneously without port conflicts.
+
+### 2. Credential Standardization
+
+**Before**: `neo4j/password`, `neo4j/testpassword`, `neo4j/sophia_dev`  
+**After**: `neo4j/logosdev` (everywhere)
+
+### 3. Shared Test Utilities
+
+**Package**: `logos_test_utils` (exported from logos repo)
+
+**Contents**:
+- `docker.py` - Container health checks, name resolution
+- `env.py` - Load `.env.test` with consistent schema
+- `milvus.py` - Milvus connection helpers, config
+- `neo4j.py` - Neo4j driver setup, query runners
+- `fixtures.py` - Pytest fixtures for common scenarios
+
+**Installation** (from other repos):
+```toml
+# In apollo/sophia/hermes/talos pyproject.toml
+[tool.poetry.group.dev.dependencies]
+logos-test-utils = { path = "../logos", develop = true }
+```
+
+## Migration Steps by Repo
+
+### For Apollo (#363)
+
+1. **Regenerate stack files**:
+   ```bash
+   cd logos
+   poetry run render-test-stacks --repo apollo
+   cp tests/e2e/stack/apollo/* ../apollo/tests/e2e/
+   ```
+
+2. **Update pyproject.toml**:
+   ```toml
+   [tool.poetry.group.dev.dependencies]
+   logos-test-utils = { path = "../logos", develop = true }
+   ```
+
+3. **Replace fixtures in conftest.py**:
+   ```python
+   # OLD
+   @pytest.fixture
+   def neo4j_driver():
+       driver = GraphDatabase.driver("bolt://localhost:7687", ...)
+   
+   # NEW
+   from logos_test_utils import get_neo4j_driver, get_neo4j_config
+   
+   @pytest.fixture
+   def neo4j_driver():
+       config = get_neo4j_config()  # Reads from .env.test
+       return get_neo4j_driver(config)
+   ```
+
+4. **Update test runner**:
+   ```bash
+   # tests/e2e/run_e2e.sh
+   source tests/e2e/.env.test
+   docker compose -f tests/e2e/docker-compose.test.apollo.yml up -d
+   ```
+
+5. **Verify**:
+   ```bash
+   poetry install
+   ./tests/e2e/run_e2e.sh
+   poetry run pytest tests/e2e/
+   ```
+
+### For Hermes (#364)
+
+1. **Regenerate stack files**:
+   ```bash
+   cd logos
+   poetry run render-test-stacks --repo hermes
+   cp tests/e2e/stack/hermes/* ../hermes/tests/integration/
+   ```
+
+2. **Replace `scripts/run_integration_stack.sh`**:
+   ```bash
+   #!/bin/bash
+   set -e
+   
+   # Source generated env
+   if [ -f tests/integration/.env.test ]; then
+       export $(grep -v '^#' tests/integration/.env.test | xargs)
+   fi
+   
+   # Start stack
+   docker compose -f tests/integration/docker-compose.test.hermes.yml up -d
+   
+   # Wait for health
+   poetry run python -c "from logos_test_utils import wait_for_milvus; wait_for_milvus()"
+   ```
+
+3. **Update credentials**:
+   - Remove references to `neo4j/password`
+   - Use `neo4j/logosdev` everywhere
+
+4. **Add shared fixtures**:
+   ```toml
+   [tool.poetry.group.dev.dependencies]
+   logos-test-utils = { path = "../logos", develop = true }
+   ```
+
+### For Sophia (#365)
+
+1. **Regenerate stack files**:
+   ```bash
+   cd logos
+   poetry run render-test-stacks --repo sophia
+   cp tests/e2e/stack/sophia/* ../sophia/tests/integration/
+   ```
+
+2. **Replace `run_prototype_integration.sh`**:
+   ```bash
+   # OLD: scripts/run_prototype_integration.sh with hardcoded ports
+   # NEW: Use generated .env.test with unique ports (37xxx)
+   ```
+
+3. **Update credentials**:
+   - Change `neo4j/sophia_dev` → `neo4j/logosdev`
+   - Update tests expecting old password
+
+4. **Adopt shared fixtures**:
+   ```python
+   # tests/conftest.py
+   from logos_test_utils import get_neo4j_config, wait_for_neo4j
+   ```
+
+### For Talos (#366)
+
+1. **Regenerate stack files**:
+   ```bash
+   cd logos
+   poetry run render-test-stacks --repo talos
+   cp tests/e2e/stack/talos/* ../talos/tests/integration/
+   ```
+
+2. **Update unique ports** (47xxx range)
+
+3. **Add shared fixtures**:
+   ```toml
+   [tool.poetry.group.dev.dependencies]
+   logos-test-utils = { path = "../logos", develop = true }
+   ```
+
+## Verification Checklist
+
+### Per Repo
+
+- [ ] Generated stack files exist in `tests/e2e/` or `tests/integration/`
+- [ ] `.env.test` has unique ports matching `repos.yaml`
+- [ ] `pyproject.toml` includes `logos-test-utils` dependency
+- [ ] Tests import from `logos_test_utils` instead of local duplicates
+- [ ] Helper scripts source `.env.test`
+- [ ] All credentials use `neo4j/logosdev`
+- [ ] CI passes with new configuration
+
+### Cross-Repo
+
+- [ ] Run tests in 2+ repos simultaneously → no port conflicts
+- [ ] Environment variables follow consistent schema
+- [ ] Documentation updated with new ports
+
+## Common Patterns
+
+### Loading Environment
+
+```python
+from logos_test_utils import load_stack_env
+
+# In conftest.py or test setup
+load_stack_env()  # Finds and loads .env.test
+```
+
+### Waiting for Services
+
+```python
+from logos_test_utils import wait_for_neo4j, wait_for_milvus
+
+@pytest.fixture(scope="session")
+def services_ready():
+    wait_for_neo4j(timeout=30)
+    wait_for_milvus(timeout=30)
+```
+
+### Getting Configuration
+
+```python
+from logos_test_utils import get_neo4j_config, get_milvus_config
+
+neo4j_cfg = get_neo4j_config()  # Reads NEO4J_URI, NEO4J_USER, etc.
+milvus_cfg = get_milvus_config()  # Reads MILVUS_HOST, MILVUS_PORT
+```
+
+## Troubleshooting
+
+### "Port already in use"
+- Check if another test suite is running
+- Verify ports in `.env.test` match `repos.yaml`
+- Use `docker ps` to find conflicting containers
+
+### "Connection refused" 
+- Ensure services are healthy: `docker compose ps`
+- Check container names match service_prefix in `repos.yaml`
+- Verify firewall isn't blocking localhost ports
+
+### "Authentication failed"
+- Confirm using `neo4j/logosdev` everywhere
+- Check `.env.test` has correct NEO4J_PASSWORD
+- Regenerate stack files if old credentials cached
+
+## Benefits
+
+1. **Parallel Testing**: Run all repo tests simultaneously
+2. **Consistent Behavior**: Same Neo4j/Milvus versions across repos
+3. **Reduced Duplication**: Shared fixtures = single source of truth
+4. **Easier Onboarding**: One pattern to learn
+5. **Faster Debugging**: Standard env vars and helpers
+
+## Timeline
+
+- **Week 1**: Logos repo complete (feature/logos-test-utils branch)
+- **Week 2**: Apollo + Hermes migration
+- **Week 3**: Sophia + Talos migration
+- **Week 4**: Documentation + CI validation
+
+## Questions?
+
+See issues #326, #358, #363-367 or the parent tracking issue.

--- a/infra/docker-compose.hcg.dev.yml
+++ b/infra/docker-compose.hcg.dev.yml
@@ -10,7 +10,7 @@ services:
       - "${NEO4J_HTTP_PORT:-7474}:7474"  # HTTP
       - "${NEO4J_BOLT_PORT:-7687}:7687"  # Bolt
     environment:
-      - NEO4J_AUTH=neo4j/neo4jtest
+      - NEO4J_AUTH=neo4j/logosdev
       - NEO4JLABS_PLUGINS=${NEO4JLABS_PLUGINS:-["apoc", "n10s"]}
       - NEO4J_dbms_security_procedures_unrestricted=apoc.*,n10s.*
       - NEO4J_dbms_security_procedures_allowlist=apoc.*,n10s.*

--- a/infra/test_stack/repos.yaml
+++ b/infra/test_stack/repos.yaml
@@ -48,9 +48,12 @@ repos:
       - milvus-minio
       - milvus
     context:
-      neo4j_password: testpassword
+      neo4j_http_port: "27474"
+      neo4j_bolt_port: "27687"
+      milvus_grpc_port: "29530"
+      milvus_metrics_port: "29091"
     env:
-      NEO4J_PASSWORD: testpassword
+      NEO4J_URI: "bolt://neo4j:{neo4j_bolt_port}"
 
   hermes:
     path: ../hermes
@@ -60,8 +63,13 @@ repos:
       - milvus-etcd
       - milvus-minio
       - milvus
+    context:
+      milvus_grpc_port: "19530"
+      milvus_metrics_port: "19091"
     env:
-      NEO4J_URI: "bolt://neo4j:{neo4j_bolt_port}"
+      NEO4J_URI: "bolt://neo4j:7687"
+      MILVUS_HOST: milvus
+      MILVUS_PORT: "{milvus_grpc_port}"
 
   sophia:
     path: ../sophia
@@ -73,9 +81,12 @@ repos:
       - milvus-minio
       - milvus
     context:
-      neo4j_password: sophia_dev
+      neo4j_http_port: "37474"
+      neo4j_bolt_port: "37687"
+      milvus_grpc_port: "39530"
+      milvus_metrics_port: "39091"
     env:
-      NEO4J_PASSWORD: sophia_dev
+      NEO4J_URI: "bolt://neo4j:{neo4j_bolt_port}"
 
   talos:
     path: ../talos
@@ -83,6 +94,10 @@ repos:
     volume_prefix: talos_test
     services:
       - neo4j
+    context:
+      neo4j_http_port: "47474"
+      neo4j_bolt_port: "47687"
     env:
+      NEO4J_URI: "bolt://neo4j:{neo4j_bolt_port}"
       MILVUS_HOST: ""
       MILVUS_PORT: ""

--- a/logos_test_utils/fixtures.py
+++ b/logos_test_utils/fixtures.py
@@ -1,4 +1,45 @@
-"""Pytest fixtures that can be reused across LOGOS repos."""
+"""Pytest fixtures that can be reused across LOGOS repos.
+
+This module provides ready-to-use pytest fixtures for downstream repos
+(apollo, hermes, sophia, talos) to consume when they adopt the standardized
+test infrastructure.
+
+Usage in downstream repos:
+    1. Add logos_test_utils to dev dependencies in pyproject.toml:
+       ```toml
+       [tool.poetry.group.dev.dependencies]
+       logos-test-utils = {path = "../logos", develop = true}
+       ```
+
+    2. Import fixtures in conftest.py:
+       ```python
+       from logos_test_utils.fixtures import (
+           stack_env,
+           neo4j_config,
+           neo4j_driver,
+           load_cypher,
+       )
+       ```
+
+    3. Use fixtures in tests:
+       ```python
+       def test_something(neo4j_driver):
+           with neo4j_driver.session() as session:
+               result = session.run("RETURN 1 AS test")
+               assert result.single()["test"] == 1
+       ```
+
+Note: The logos repo itself typically imports helper functions directly
+(e.g., `get_neo4j_config()`) rather than using these fixtures, since its
+tests pre-date fixture standardization. New tests should consider using
+fixtures for consistency with downstream repos.
+
+Available fixtures:
+- stack_env: Parsed environment from .env.test
+- neo4j_config: Neo4j connection configuration
+- neo4j_driver: Connected Neo4j driver (session-scoped, auto-cleanup)
+- load_cypher: Helper function to load .cypher files
+"""
 
 from __future__ import annotations
 

--- a/logos_test_utils/milvus.py
+++ b/logos_test_utils/milvus.py
@@ -22,8 +22,8 @@ class MilvusConfig:
 
 def get_milvus_config(env: Mapping[str, str] | None = None) -> MilvusConfig:
     values = env or load_stack_env()
-    host = get_env_value("MILVUS_HOST", values, "milvus") or "milvus"
-    port = get_env_value("MILVUS_PORT", values, "19530") or "19530"
+    host = get_env_value("MILVUS_HOST", values, "milvus")
+    port = get_env_value("MILVUS_PORT", values, "19530")
     container = resolve_container_name(
         "MILVUS_CONTAINER",
         "logos-phase2-test-milvus",

--- a/logos_test_utils/neo4j.py
+++ b/logos_test_utils/neo4j.py
@@ -26,12 +26,9 @@ def get_neo4j_config(env: Mapping[str, str] | None = None) -> Neo4jConfig:
     """Build a ``Neo4jConfig`` from environment sources."""
 
     values = env or load_stack_env()
-    uri = (
-        get_env_value("NEO4J_URI", values, "bolt://localhost:7687")
-        or "bolt://localhost:7687"
-    )
-    user = get_env_value("NEO4J_USER", values, "neo4j") or "neo4j"
-    password = get_env_value("NEO4J_PASSWORD", values, "neo4jtest") or "neo4jtest"
+    uri = get_env_value("NEO4J_URI", values, "bolt://localhost:7687")
+    user = get_env_value("NEO4J_USER", values, "neo4j")
+    password = get_env_value("NEO4J_PASSWORD", values, "logosdev")
     container = resolve_container_name(
         "NEO4J_CONTAINER",
         "logos-hcg-neo4j",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 packages = [
     { include = "logos_tools" },
     { include = "logos_hcg" },
+    { include = "logos_test_utils" },
     { include = "logos_observability" },
     { include = "logos_persona" },
     { include = "logos_cwm_e" },
@@ -68,6 +69,7 @@ types-requests = "^2.31.0"
 [tool.poetry.scripts]
 logos-generate-issues = "logos_tools.generate_issues:main"
 logos-create-issues-by-epoch = "logos_tools.create_issues_by_epoch:main"
+render-test-stacks = "infra.scripts.render_test_stacks:main"
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/tests/phase2/fixtures.py
+++ b/tests/phase2/fixtures.py
@@ -15,6 +15,10 @@ from typing import Any
 import pytest
 import requests
 
+from logos_test_utils.env import load_stack_env
+from logos_test_utils.milvus import get_milvus_config
+from logos_test_utils.neo4j import get_neo4j_config
+
 # Try to import Apollo SDK clients
 try:
     from apollo.client.hermes_client import HermesClient
@@ -26,15 +30,22 @@ try:
 except ImportError:
     APOLLO_SDK_AVAILABLE = False
 
+# Load stack environment and configs
+STACK_ENV = load_stack_env()
+NEO4J_CONFIG = get_neo4j_config(STACK_ENV)
+MILVUS_CONFIG = get_milvus_config(STACK_ENV)
+
 # Service URLs
 SOPHIA_URL = os.getenv("SOPHIA_URL", "http://localhost:8001")
 HERMES_URL = os.getenv("HERMES_URL", "http://localhost:8002")
 APOLLO_URL = os.getenv("APOLLO_URL", "http://localhost:8003")
-NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
-NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
-NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "neo4jtest")
-MILVUS_HOST = os.getenv("MILVUS_HOST", "localhost")
-MILVUS_PORT = int(os.getenv("MILVUS_PORT", "19530"))
+
+# Extract Neo4j/Milvus config from helpers
+NEO4J_URI = NEO4J_CONFIG.uri
+NEO4J_USER = NEO4J_CONFIG.user
+NEO4J_PASSWORD = NEO4J_CONFIG.password
+MILVUS_HOST = MILVUS_CONFIG.host
+MILVUS_PORT = int(MILVUS_CONFIG.port)
 
 
 # ============================================================================

--- a/tests/phase2/test_phase2_end_to_end.py
+++ b/tests/phase2/test_phase2_end_to_end.py
@@ -20,6 +20,10 @@ from pathlib import Path
 import pytest
 import requests
 
+from logos_test_utils.env import load_stack_env
+from logos_test_utils.milvus import get_milvus_config
+from logos_test_utils.neo4j import get_neo4j_config
+
 # Try to import Apollo SDK clients
 try:
     from apollo.client.hermes_client import HermesClient
@@ -47,15 +51,22 @@ pytestmark = pytest.mark.skipif(
 # Repository root
 REPO_ROOT = Path(__file__).parent.parent.parent
 
+# Load stack environment and configs
+STACK_ENV = load_stack_env()
+NEO4J_CONFIG = get_neo4j_config(STACK_ENV)
+MILVUS_CONFIG = get_milvus_config(STACK_ENV)
+
 # Service URLs - use environment variables with defaults
 SOPHIA_URL = os.getenv("SOPHIA_URL", "http://localhost:8001")
 HERMES_URL = os.getenv("HERMES_URL", "http://localhost:8002")
 APOLLO_URL = os.getenv("APOLLO_URL", "http://localhost:8003")
-NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
-NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
-NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "neo4jtest")
-MILVUS_HOST = os.getenv("MILVUS_HOST", "localhost")
-MILVUS_PORT = int(os.getenv("MILVUS_PORT", "19530"))
+
+# Extract Neo4j/Milvus config from helpers
+NEO4J_URI = NEO4J_CONFIG.uri
+NEO4J_USER = NEO4J_CONFIG.user
+NEO4J_PASSWORD = NEO4J_CONFIG.password
+MILVUS_HOST = MILVUS_CONFIG.host
+MILVUS_PORT = int(MILVUS_CONFIG.port)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Completes the test standardization work started in #367 by addressing quality issues found during pre-merge audit. Fixes #369.

## Changes Made

### 1. **Credentials Fixed** ✅
- Updated `logos_test_utils/neo4j.py` default: `neo4jtest` → `logosdev`
- Updated `infra/docker-compose.hcg.dev.yml`: `NEO4J_AUTH=neo4j/logosdev`
- All hardcoded old credentials removed from test infrastructure

### 2. **Code Cleanup** ✅
- Removed redundant `or "neo4jtest"` fallback patterns in:
  - `logos_test_utils/neo4j.py` (simplified to single default)
  - `logos_test_utils/milvus.py` (removed unnecessary `or` chains)
- Helpers now have single source of truth per config value

### 3. **Phase 2 Test Migration** ✅
- Updated `tests/phase2/test_phase2_end_to_end.py` to import from `logos_test_utils`
- Updated `tests/phase2/fixtures.py` to use `get_neo4j_config()` and `get_milvus_config()`
- Phase 2 tests now consistent with Phase 1 test patterns

### 4. **Documentation** ✅
- Added comprehensive docstring to `logos_test_utils/fixtures.py`
- Explains fixtures are export API for downstream repos (apollo, hermes, sophia, talos)
- Includes usage examples and import patterns

## Verification
- ✅ Python syntax validated for all modified files
- ✅ No remaining `neo4jtest` references in test infrastructure
- ✅ Credential standardization complete across helpers and compose files

## Impact
- **Before**: Test standardization ~70% complete, inconsistent patterns, old credentials
- **After**: Clean, complete foundation ready for downstream repo adoption (#363-366)

## Testing Plan
Once merged into `feature/logos-test-utils`:
1. Verify Phase 1 tests pass with `logosdev` credentials
2. Verify Phase 2 tests pass using standardized helpers
3. Check integration test stack uses consistent configuration

## Related Issues
- Fixes #369 (this ticket)
- Part of #367 (logos repo standardization)
- Unblocks #363, #364, #365, #366 (downstream adoption)

---

**Note**: This PR targets `feature/logos-test-utils` (not main). After merge, the feature branch will be clean and ready for final merge to main.