### PR TITLE
[logos] Use Poetry for SHACL loader (#390)

### DIFF
--- a/.github/workflows/shacl-neo4j-validation.yml
+++ b/.github/workflows/shacl-neo4j-validation.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           echo "## SHACL Validation via Neo4j n10s" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          python ontology/load_shacl_via_n10s.py \
+          poetry run python ontology/load_shacl_via_n10s.py \
             --uri bolt://localhost:7687 \
             --user neo4j \
             --password neo4jtest \


### PR DESCRIPTION
## Summary
Run the SHACL loader inside the Poetry venv so the `neo4j` dependency is available during the workflow.

Closes #390

## Changes
- Invoke `ontology/load_shacl_via_n10s.py` via `poetry run` in the SHACL Neo4j workflow.

## Testing
- ⚠️ Not run (workflow YAML change only)
