### PR TITLE
fix(infra): add milvus service to talos stack config

### DIFF
--- a/infra/test_stack/repos.yaml
+++ b/infra/test_stack/repos.yaml
@@ -94,10 +94,11 @@ repos:
     volume_prefix: talos_test
     services:
       - neo4j
+      - milvus
     context:
       neo4j_http_port: "47474"
       neo4j_bolt_port: "47687"
+      milvus_grpc_port: "49530"
+      milvus_metrics_port: "49091"
     env:
       NEO4J_URI: "bolt://neo4j:{neo4j_bolt_port}"
-      MILVUS_HOST: ""
-      MILVUS_PORT: ""


### PR DESCRIPTION
## Summary
Add milvus service configuration to talos in `repos.yaml` so that `render-test-stacks --repo talos` generates the correct stack files.

## Changes
- Added `services: [neo4j, milvus]` to talos entry
- Added milvus port configuration (49530 gRPC, 49091 HTTP)

## Context
Discovered while working on talos#22 - the stack generator was only producing neo4j config, but talos uses Milvus for vector storage.