### PR TITLE
feat(ontology): add MediaSample node type for media ingestion

### DIFF
--- a/ontology/core_ontology.cypher
+++ b/ontology/core_ontology.cypher
@@ -88,6 +88,23 @@ CREATE CONSTRAINT logos_imagined_state_uuid IF NOT EXISTS
 FOR (is:ImaginedState)
 REQUIRE is.uuid IS UNIQUE;
 
+//// Phase 2 P2-M3: MediaSample node constraints (media ingestion)
+CREATE CONSTRAINT logos_media_sample_uuid IF NOT EXISTS
+FOR (ms:MediaSample)
+REQUIRE ms.uuid IS UNIQUE;
+
+CREATE INDEX logos_media_sample_media_type IF NOT EXISTS
+FOR (ms:MediaSample)
+ON (ms.media_type);
+
+CREATE INDEX logos_media_sample_timestamp IF NOT EXISTS
+FOR (ms:MediaSample)
+ON (ms.timestamp);
+
+CREATE INDEX logos_media_sample_file_hash IF NOT EXISTS
+FOR (ms:MediaSample)
+ON (ms.file_hash);
+
 //// CWM-A: Abstract/Associative World Model node constraints
 CREATE CONSTRAINT logos_fact_uuid IF NOT EXISTS
 FOR (f:Fact)
@@ -190,6 +207,13 @@ ON (abs.domain);
 //// - (:PerceptionFrame)-[:TRIGGERED_SIMULATION]->(:ImaginedProcess) — Frame that initiated simulation
 //// - (:ImaginedProcess)-[:PREDICTS]->(:ImaginedState) — Process predicting future state
 //// - (:ImaginedState)-[:PRECEDES]->(:ImaginedState) — Temporal ordering of imagined states
+
+//// Phase 2 P2-M3: Extended relationship types for media ingestion
+//// - (:MediaSample)-[:HAS_EMBEDDING]->(:Embedding) — Media linked to Milvus embedding
+//// - (:MediaSample)-[:EXTRACTED_FROM]->(:MediaSample) — Frame extracted from video
+//// - (:MediaSample)-[:FEEDS]->(:SimulationContext) — Media used as simulation input
+//// - (:MediaSample)-[:PRODUCES]->(:PerceptionFrame) — Media processed into perception frame
+//// - (:MediaSample)-[:UPLOADED_BY]->(:Session) — Upload session tracking
 
 //// CWM-A: Relationship types for abstract/associative world model
 //// - (:Fact)-[:ABOUT]->(:Concept|:Entity) — Fact concerns this node

--- a/ontology/shacl_shapes.ttl
+++ b/ontology/shacl_shapes.ttl
@@ -416,6 +416,110 @@ logos:PerceptionFrameShape
         rdfs:comment "Additional metadata about the frame" ;
     ] .
 
+# Phase 2 P2-M3: MediaSample Shape (media ingestion)
+logos:MediaSampleShape
+    a sh:NodeShape ;
+    sh:targetClass logos:MediaSample ;
+    rdfs:label "Media Sample Shape" ;
+    rdfs:comment "Validates ingested media samples (images, video, audio)" ;
+    sh:property [
+        sh:path logos:uuid ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        rdfs:label "UUID" ;
+        rdfs:comment "Unique identifier for media sample" ;
+    ] ;
+    sh:property [
+        sh:path logos:media_type ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:in ("image" "video" "audio" "video_frame") ;
+        rdfs:label "Media Type" ;
+        rdfs:comment "Type of media: image, video, audio, or video_frame" ;
+    ] ;
+    sh:property [
+        sh:path logos:file_path ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        rdfs:label "File Path" ;
+        rdfs:comment "Storage path (local or object storage URL)" ;
+    ] ;
+    sh:property [
+        sh:path logos:file_size ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:integer ;
+        rdfs:label "File Size" ;
+        rdfs:comment "File size in bytes" ;
+    ] ;
+    sh:property [
+        sh:path logos:file_hash ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        rdfs:label "File Hash" ;
+        rdfs:comment "SHA256 hash of file content for deduplication" ;
+    ] ;
+    sh:property [
+        sh:path logos:timestamp ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        rdfs:label "Timestamp" ;
+        rdfs:comment "When the sample was ingested" ;
+    ] ;
+    sh:property [
+        sh:path logos:mime_type ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        rdfs:label "MIME Type" ;
+        rdfs:comment "MIME type (e.g., image/jpeg, video/mp4)" ;
+    ] ;
+    sh:property [
+        sh:path logos:original_filename ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        rdfs:label "Original Filename" ;
+        rdfs:comment "Original filename from upload" ;
+    ] ;
+    sh:property [
+        sh:path logos:width ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:integer ;
+        rdfs:label "Width" ;
+        rdfs:comment "Width in pixels (for images/video)" ;
+    ] ;
+    sh:property [
+        sh:path logos:height ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:integer ;
+        rdfs:label "Height" ;
+        rdfs:comment "Height in pixels (for images/video)" ;
+    ] ;
+    sh:property [
+        sh:path logos:duration_ms ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:integer ;
+        rdfs:label "Duration (ms)" ;
+        rdfs:comment "Duration in milliseconds (for audio/video)" ;
+    ] ;
+    sh:property [
+        sh:path logos:frame_index ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:integer ;
+        rdfs:label "Frame Index" ;
+        rdfs:comment "Frame number (for video_frame type)" ;
+    ] ;
+    sh:property [
+        sh:path logos:question ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        rdfs:label "Perception Question" ;
+        rdfs:comment "Optional question for perception pipeline" ;
+    ] .
+
 logos:ImaginedProcessShape
     a sh:NodeShape ;
     sh:targetClass logos:ImaginedProcess ;


### PR DESCRIPTION
## Summary

Add `MediaSample` node type to the HCG ontology to formalize the schema used by Sophia's media ingestion service.

## Changes

### Neo4j Constraints & Indexes (`core_ontology.cypher`)
- `logos_media_sample_uuid`: Unique constraint on uuid
- `logos_media_sample_media_type`: Index for type filtering  
- `logos_media_sample_timestamp`: Index for temporal queries
- `logos_media_sample_file_hash`: Index for deduplication

### SHACL Shape (`shacl_shapes.ttl`)
`MediaSampleShape` with 13 properties:
- **Required:** uuid, media_type, file_path, file_size, file_hash, timestamp
- **Optional:** mime_type, original_filename, width, height, duration_ms, frame_index, question

### Relationship Types (documented)
```
(:MediaSample)-[:HAS_EMBEDDING]->(:Embedding)
(:MediaSample)-[:EXTRACTED_FROM]->(:MediaSample)
(:MediaSample)-[:FEEDS]->(:SimulationContext)
(:MediaSample)-[:PRODUCES]->(:PerceptionFrame)
(:MediaSample)-[:UPLOADED_BY]->(:Session)
```

## Context

Sophia already creates `MediaSample` nodes via `hcg_client.add_node()` in the media ingestion service. This PR formalizes that schema in the logos ontology for:
- Consistent validation via SHACL
- Proper Neo4j indexes for query performance
- Documentation of relationship patterns

## Testing

- `tests/test_ontology_extension.py` passes ✅

Closes #400