### PR TITLE
[logos] Add ecosystem standards documentation

### DIFF
--- a/docs/GIT_PROJECT_STANDARDS.md
+++ b/docs/GIT_PROJECT_STANDARDS.md
@@ -1,0 +1,401 @@
+# LOGOS Ecosystem Git & Project Standards
+
+This document defines the canonical Git workflow and project conventions for the entire LOGOS ecosystem. All repositories must follow these patterns.
+
+**Canonical Location:** `logos/docs/GIT_PROJECT_STANDARDS.md`  
+**Last Updated:** December 2025
+
+---
+
+## Overview
+
+The LOGOS ecosystem consists of five repositories that share contracts, ontology, and standards. This document ensures consistent workflows across all repos.
+
+| Repo | Purpose |
+|------|---------|
+| **logos** | Foundry—canonical contracts, ontology, SDKs, shared tooling, ecosystem standards |
+| **sophia** | Non-linguistic cognitive core (Orchestrator, CWM-A/G, Planner, Executor) |
+| **hermes** | Stateless language & embedding utility (STT, TTS, NLP, embeddings) |
+| **talos** | Hardware abstraction layer for sensors/actuators |
+| **apollo** | Thin client UI and command layer |
+
+**Logos is upstream.** Changes to contracts, ontology, or standards in logos ripple to all downstream repos.
+
+---
+
+## Branch Strategy
+
+### Never Work Directly on `main`
+
+All changes—no matter how small—require a feature branch and pull request.
+
+### Branch Naming Convention
+
+```
+{kind}/{repo}{issue-number}-{short-kebab}
+```
+
+**Examples:**
+```
+feature/logos420-testing-standards
+fix/sophia88-cwm-state-sync
+docs/hermes15-api-documentation
+chore/apollo32-dependency-update
+refactor/talos99-executor-cleanup
+```
+
+**Why include the repo prefix?**
+- Branches are identifiable when working across multiple repos
+- GitHub search works across the org
+- Easy to correlate branches with tracking issues
+
+### Branch Kinds
+
+| Kind | When to Use |
+|------|-------------|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation only |
+| `chore/` | Dependencies, CI, tooling |
+| `refactor/` | Code restructuring without behavior change |
+| `test/` | Test additions or fixes |
+
+---
+
+## Commit Messages
+
+### Format
+
+```
+{type}: {short description}
+
+{optional body with more detail}
+
+{optional footer with issue references}
+```
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation |
+| `style` | Formatting, no code change |
+| `refactor` | Code restructuring |
+| `test` | Adding/fixing tests |
+| `chore` | Dependencies, CI, tooling |
+
+### Examples
+
+```
+feat: add retry logic to HCG client
+
+Implements exponential backoff for Neo4j connection failures.
+Max retries: 3, base delay: 1s.
+
+Closes #420
+```
+
+```
+fix: handle null values in CWM state sync
+
+Part of c-daly/logos#350
+```
+
+---
+
+## Pull Requests
+
+### Title Format
+
+```
+[{repo}] {Short imperative description}
+```
+
+**Examples:**
+```
+[logos] Add testing standards documentation
+[sophia] Fix CWM state synchronization
+[hermes] Update embedding model configuration
+```
+
+### Body Template
+
+```markdown
+## Summary
+Brief description of what this PR does.
+
+Closes #420
+
+## Changes
+- Added `docs/TESTING_STANDARDS.md`
+- Updated cross-references in AGENTS.md
+
+## Testing
+- `./scripts/run_tests.sh unit` – ✅
+- `poetry run ruff check .` – ✅
+- `poetry run mypy src/` – ✅
+
+## Downstream Impact
+_Does this change affect other repos?_
+
+None / List affected repos and describe impact
+```
+
+### Requirements
+
+- [ ] Branch is up to date with `main`
+- [ ] All tests pass
+- [ ] Linting passes (`ruff check .`)
+- [ ] Type checking passes (`mypy src/`)
+- [ ] PR description is complete
+- [ ] Issue is linked (`Closes #N`)
+
+---
+
+## Cross-Repository Changes
+
+Many changes in LOGOS span multiple repositories. These require coordination.
+
+### Workflow
+
+1. **Create a tracking issue in logos**
+   - Describe the full scope of the change
+   - List all affected repositories
+   - Define the rollout order
+
+2. **Create branches in each affected repo**
+   - Use consistent naming: `chore/logos420-feature-name`
+   - Reference the tracking issue in each branch
+
+3. **Merge logos first**
+   - Logos defines contracts, ontology, and standards
+   - Downstream repos depend on these definitions
+
+4. **Create linked PRs in downstream repos**
+   - Reference the tracking issue: `Part of c-daly/logos#420`
+   - Reference the logos PR if it contains the contract/standard
+
+5. **Close the tracking issue**
+   - Only after all downstream PRs are merged
+   - Add a summary comment listing all merged PRs
+
+### Example: Contract Change
+
+```markdown
+# Tracking Issue: logos#420
+
+## Summary
+Update the HCG API contract to add media node support.
+
+## Affected Repos
+- [x] logos – Contract definition (#420)
+- [ ] sophia – Implement new endpoints (#XX)
+- [ ] hermes – Update SDK (#XX)
+- [ ] apollo – Update client (#XX)
+
+## Rollout Order
+1. logos – Define contract
+2. hermes – Update SDK (depends on contract)
+3. sophia – Implement API (depends on SDK)
+4. apollo – Update UI (depends on API)
+
+## Related PRs
+- c-daly/logos#421 – Contract definition
+- c-daly/hermes#XX – SDK update
+- c-daly/sophia#XX – API implementation
+- c-daly/apollo#XX – Client update
+```
+
+---
+
+## Issue Management
+
+### Issue Title Format
+
+```
+[{repo}] {Short description}
+```
+
+**Examples:**
+```
+[logos] Add testing standards documentation
+[sophia] CWM state not syncing on restart
+[hermes] Support for new embedding model
+```
+
+### Labels
+
+Standard labels across all repos:
+
+| Label | Description |
+|-------|-------------|
+| `bug` | Something isn't working |
+| `enhancement` | New feature request |
+| `documentation` | Documentation only |
+| `infrastructure` | CI, tooling, deployment |
+| `testing` | Test-related changes |
+| `breaking-change` | Requires coordination |
+| `cross-repo` | Spans multiple repositories |
+
+### Linking Issues
+
+```markdown
+# In commit messages
+Closes #420
+Fixes #420
+Part of c-daly/logos#420
+
+# In PR descriptions
+Closes #420
+Related to c-daly/sophia#64
+Part of c-daly/logos#420
+```
+
+---
+
+## Contract Changes
+
+Contracts in `logos/contracts/` define the API interfaces between services. Changes require extra coordination.
+
+### Before Modifying a Contract
+
+1. **Identify consumers** – Which repos implement or call this API?
+2. **Create a tracking issue** – Document the migration plan
+3. **Design for backward compatibility** – Add fields, don't remove
+4. **Coordinate the rollout** – Logos first, then downstream
+
+### Breaking Changes
+
+If a breaking change is unavoidable:
+
+1. Add a `breaking-change` label to the issue
+2. Document the migration path in the PR
+3. Create issues in all affected repos
+4. Coordinate deployment timing
+5. Update the contract version
+
+---
+
+## Code Review
+
+### Reviewer Checklist
+
+- [ ] Code is clear and well-documented
+- [ ] Tests cover the changes
+- [ ] No unrelated changes included
+- [ ] Backward compatibility maintained (or breaking change documented)
+- [ ] Cross-repo impact documented (if applicable)
+
+### Author Responsibilities
+
+- Keep PRs focused and small when possible
+- Respond to review comments promptly
+- Update the PR based on feedback
+- Don't merge without approval
+
+---
+
+## Release Process
+
+### Versioning
+
+All repos follow [Semantic Versioning](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH
+
+MAJOR – Breaking changes
+MINOR – New features (backward compatible)
+PATCH – Bug fixes (backward compatible)
+```
+
+### Tagging
+
+```bash
+git tag -a v1.2.3 -m "Release v1.2.3"
+git push origin v1.2.3
+```
+
+### Changelog
+
+Maintain a `CHANGELOG.md` in each repo:
+
+```markdown
+## [1.2.3] - 2025-12-05
+
+### Added
+- New feature X
+
+### Fixed
+- Bug in Y
+
+### Changed
+- Updated Z behavior
+```
+
+---
+
+## Quick Reference
+
+### Daily Workflow
+
+```bash
+# Start work
+git checkout main
+git pull
+git checkout -b feature/logos420-my-feature
+
+# Make changes
+# ... edit files ...
+
+# Commit
+git add .
+git commit -m "feat: add my feature"
+
+# Push
+git push -u origin feature/logos420-my-feature
+
+# Create PR via GitHub
+```
+
+### Before Pushing
+
+```bash
+# Run tests
+./scripts/run_tests.sh unit
+
+# Check linting
+poetry run ruff check .
+poetry run ruff format --check .
+
+# Check types
+poetry run mypy src/
+```
+
+### Sync with Main
+
+```bash
+git checkout main
+git pull
+git checkout feature/logos420-my-feature
+git rebase main
+# or: git merge main
+```
+
+---
+
+## Related Documentation
+
+- [Testing Standards](TESTING_STANDARDS.md)
+- [Contributing Guide](../CONTRIBUTING.md)
+- [CI/CD Documentation](operations/ci/README.md)
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| Dec 2025 | Created from AGENTS.md git workflow content |

--- a/docs/TESTING_STANDARDS.md
+++ b/docs/TESTING_STANDARDS.md
@@ -1,0 +1,353 @@
+# LOGOS Ecosystem Testing Standards
+
+This document defines the canonical testing standards for the entire LOGOS ecosystem. All repositories must follow these conventions.
+
+**Canonical Location:** `logos/docs/TESTING_STANDARDS.md`  
+**Last Updated:** December 2025
+
+---
+
+## Overview
+
+Testing in the LOGOS ecosystem follows consistent patterns across all repositories. This document is the **source of truth**—individual repos may have additional detail but should not contradict these standards.
+
+### Core Principles
+
+1. **Consistency** – All repos use the same tooling (Pytest, Poetry) and CI workflows
+2. **Reliability** – Tests must be deterministic; flaky tests are fixed, not ignored
+3. **Completeness** – Integration tests with real infrastructure are mandatory in CI
+4. **Isolation** – Tests are independent and runnable in any order
+
+---
+
+## Test Categories
+
+### Unit Tests
+
+**Scope:** Individual functions, classes, and modules in isolation.
+
+| Aspect | Requirement |
+|--------|-------------|
+| Location | `tests/unit/` |
+| Dependencies | Must be mocked (`unittest.mock`, `pytest-mock`) |
+| Speed | < 100ms per test |
+| Markers | None required |
+
+```python
+# Example unit test
+def test_parse_config():
+    config = parse_config({"host": "localhost"})
+    assert config.host == "localhost"
+```
+
+### Integration Tests
+
+**Scope:** Interaction between the application and real external services.
+
+| Aspect | Requirement |
+|--------|-------------|
+| Location | `tests/integration/` |
+| Dependencies | Real instances via Docker Compose—**never mock database drivers** |
+| Markers | `@pytest.mark.integration` |
+| Infrastructure | `docker-compose.test.yml` in each repo |
+
+```python
+@pytest.mark.integration
+def test_neo4j_crud(neo4j_client):
+    # Uses real Neo4j instance from Docker Compose
+    neo4j_client.create_node({"name": "test"})
+    result = neo4j_client.query("MATCH (n) RETURN n")
+    assert len(result) > 0
+```
+
+### End-to-End Tests
+
+**Scope:** Full user flows across multiple services.
+
+| Aspect | Requirement |
+|--------|-------------|
+| Location | `tests/e2e/` |
+| Dependencies | Full service stack via Docker Compose |
+| Markers | `@pytest.mark.e2e` |
+| Trigger | Explicit env var (e.g., `RUN_E2E=1`) |
+
+```python
+@pytest.mark.e2e
+def test_complete_workflow():
+    # Exercises multiple services end-to-end
+    response = client.post("/ingest", json={"text": "hello"})
+    assert response.status_code == 200
+```
+
+---
+
+## Port Allocation
+
+Each repository uses a unique port offset to prevent conflicts when running multiple test stacks simultaneously.
+
+### Standard Offset (+10000 × alphabetical position)
+
+| Repo | Offset | Neo4j HTTP | Neo4j Bolt | Milvus gRPC | Milvus Health | API |
+|------|--------|------------|------------|-------------|---------------|-----|
+| apollo | +10000 | 17474 | 17687 | 29530 | 19091 | 18000 |
+| hermes | +20000 | 27474 | 27687 | 39530 | 29091 | 28000 |
+| logos | +30000 | 37474 | 37687 | 49530 | 39091 | 38000 |
+| sophia | +40000 | 47474 | 47687 | 59530 | 49091 | 48000 |
+| talos | +50000 | 57474 | 57687 | 69530 | 59091 | 58000 |
+
+### Environment Variables
+
+Each repo's test stack should set these automatically, but for manual runs:
+
+```bash
+# Logos example (offset +30000)
+export NEO4J_URI=bolt://localhost:37687
+export NEO4J_HTTP=http://localhost:37474
+export MILVUS_HOST=localhost
+export MILVUS_PORT=49530
+```
+
+---
+
+## Tooling Stack
+
+All Python repositories must use:
+
+| Tool | Purpose | Command |
+|------|---------|---------|
+| `pytest` | Test runner | `poetry run pytest` |
+| `poetry` | Dependency management | `poetry install` |
+| `ruff` | Linting and formatting | `poetry run ruff check .` |
+| `mypy` | Type checking | `poetry run mypy src/` |
+| `pytest-cov` | Coverage | `poetry run pytest --cov` |
+
+### Quick Commands
+
+Each repo should provide a `run_tests.sh` script:
+
+```bash
+./scripts/run_tests.sh all          # Run all tests
+./scripts/run_tests.sh unit         # Unit tests only
+./scripts/run_tests.sh integration  # Integration tests
+./scripts/run_tests.sh e2e          # End-to-end tests
+./scripts/run_tests.sh up           # Start infrastructure
+./scripts/run_tests.sh down         # Stop infrastructure
+./scripts/run_tests.sh ci           # Full CI parity
+```
+
+---
+
+## CI/CD Requirements
+
+### The "No Skip in CI" Rule
+
+**Never** skip tests solely because they are running in CI.
+
+```python
+# ❌ BAD – Don't do this
+@pytest.mark.skipif(os.environ.get("CI"), reason="slow")
+def test_something():
+    ...
+
+# ✅ GOOD – Use markers and run in specialized jobs
+@pytest.mark.integration
+def test_something():
+    ...
+```
+
+If a test requires infrastructure, the CI workflow must spin it up via Docker Compose.
+
+### Reusable Workflow
+
+All repositories must use the shared workflow:
+
+```yaml
+# .github/workflows/ci.yml
+jobs:
+  test:
+    uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@main
+    with:
+      python-version: "3.11"
+```
+
+See `logos/docs/operations/ci/README.md` for workflow documentation.
+
+---
+
+## Best Practices
+
+### Fixtures
+
+Use `pytest` fixtures for setup and teardown:
+
+```python
+@pytest.fixture
+def neo4j_client():
+    client = Neo4jClient(uri="bolt://localhost:37687")
+    yield client
+    client.close()
+
+@pytest.fixture
+def clean_database(neo4j_client):
+    yield
+    neo4j_client.run("MATCH (n) WHERE n.name STARTS WITH 'test_' DELETE n")
+```
+
+### Async Testing
+
+Use `pytest-asyncio` for async code:
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_async_handler():
+    result = await async_function()
+    assert result is not None
+```
+
+### Retry Logic for Eventual Consistency
+
+For services with async indexing (Milvus, Elasticsearch):
+
+```python
+# ✅ Good – Retry with backoff
+for _ in range(10):
+    if check_condition():
+        break
+    time.sleep(0.5)
+else:
+    pytest.fail("Condition not met after retries")
+
+# ❌ Bad – Arbitrary sleep
+time.sleep(5)  # Flaky and slow
+```
+
+### Test Isolation
+
+- Tests must be independent and runnable in any order
+- Use fixtures for setup/teardown, not test dependencies
+- Clean up test data after each test
+- Prefix test data with `test_` for easy identification and cleanup
+
+### Test Naming
+
+```python
+# Pattern: test_{action}_{scenario}_{expected_result}
+def test_create_node_with_valid_data_succeeds():
+    ...
+
+def test_create_node_with_missing_field_raises_validation_error():
+    ...
+```
+
+---
+
+## Running Tests
+
+### Local Development
+
+```bash
+# Install dependencies
+poetry install
+
+# Run unit tests (fast feedback)
+poetry run pytest tests/unit/
+
+# Run with coverage
+poetry run pytest --cov=src --cov-report=html
+
+# Run specific test
+poetry run pytest tests/unit/test_client.py::test_connection -v
+```
+
+### With Infrastructure
+
+```bash
+# Start test infrastructure
+./scripts/run_tests.sh up
+
+# Run integration tests
+./scripts/run_tests.sh integration
+
+# Stop and clean up
+./scripts/run_tests.sh down
+```
+
+### Full CI Parity
+
+```bash
+# Run exactly what CI runs
+./scripts/run_tests.sh ci
+```
+
+---
+
+## Troubleshooting
+
+### Port Conflicts
+
+If services fail with "port already in use":
+
+```bash
+# Check what's using the port
+lsof -i :37687
+
+# Stop any existing containers
+./scripts/run_tests.sh down
+docker ps | grep test | awk '{print $1}' | xargs docker stop 2>/dev/null
+```
+
+### Neo4j Won't Start
+
+```bash
+# Check container logs
+docker logs logos-test-neo4j
+
+# Clear volumes and restart
+./scripts/run_tests.sh clean
+./scripts/run_tests.sh up
+```
+
+### Milvus Health Check Failing
+
+Milvus can take 60-90 seconds to become healthy:
+
+```bash
+# Check dependencies first
+docker logs logos-test-milvus-etcd
+docker logs logos-test-milvus-minio
+
+# Then check milvus
+docker logs logos-test-milvus
+```
+
+### Tests Can't Connect to Services
+
+Ensure environment variables match the port allocation:
+
+```bash
+# Source the test environment
+source tests/e2e/stack/logos/.env.test
+
+# Or set manually
+export NEO4J_URI=bolt://localhost:37687
+```
+
+---
+
+## Related Documentation
+
+- [CI/CD Documentation](operations/ci/README.md)
+- [Port Reference](operations/PORT_REFERENCE.md)
+- [Phase 2 Verification](operations/PHASE2_VERIFY.md)
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| Dec 2025 | Consolidated from AGENTS.md and operations/TESTING.md |
+| Nov 2025 | Added port standardization |
+| Oct 2025 | Initial version |


### PR DESCRIPTION
## Summary

Create standalone documentation for testing and git standards that are referenced in `AGENTS.md` but were missing from the repository.

Closes #427

## Changes

- Added `docs/TESTING_STANDARDS.md` with:
  - Test categories (unit, integration, e2e) and their requirements
  - Port allocation table for all repos (+10000 offset pattern)
  - Tooling stack (pytest, poetry, ruff, mypy)
  - CI/CD requirements and "no skip in CI" rule
  - Best practices for fixtures, async testing, test isolation

- Added `docs/GIT_PROJECT_STANDARDS.md` with:
  - Branch naming conventions (`{kind}/{repo}{issue}-{description}`)
  - Commit message format (conventional commits)
  - PR workflow and template
  - Cross-repo change coordination process
  - Contract change procedures

## Testing

Documentation only—no code changes.

## Downstream Impact

These documents are referenced in `AGENTS.md` and will be used across all ecosystem repos. No breaking changes.