### PR TITLE
chore: standardize ports to logos +30000 offset

### DIFF
--- a/.github/workflows/phase2-e2e.yml
+++ b/.github/workflows/phase2-e2e.yml
@@ -203,7 +203,7 @@ jobs:
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: neo4jtest
           MILVUS_HOST: localhost
-          MILVUS_PORT: 39530
+          MILVUS_PORT: 49530
           SOPHIA_API_KEY: test-ci-key
           HERMES_PORT: 8002
           APOLLO_PORT: 8003
@@ -220,7 +220,7 @@ jobs:
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: neo4jtest
           MILVUS_HOST: localhost
-          MILVUS_PORT: 39530
+          MILVUS_PORT: 49530
           SOPHIA_API_KEY: test-ci-key
       
       - name: Stop services

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,14 +50,17 @@ This repository defines the canonical standards for the entire LOGOS ecosystem. 
 | Git workflow | `docs/GIT_PROJECT_STANDARDS.md` |
 | Port allocation | `docs/TESTING_STANDARDS.md` (Port Allocation section) |
 
-### Port allocation (+10000 offset, alphabetical)
-| Repo | Neo4j HTTP | Neo4j Bolt | Milvus gRPC | Milvus Health | API |
-|------|------------|------------|-------------|---------------|-----|
-| apollo | 17474 | 17687 | 29530 | 19091 | 18000 |
-| hermes | 27474 | 27687 | 39530 | 29091 | 28000 |
-| logos | 37474 | 37687 | 49530 | 39091 | 38000 |
-| sophia | 47474 | 47687 | 59530 | 49091 | 48000 |
-| talos | 57474 | 57687 | 69530 | 59091 | 58000 |
+### Port allocation (base + offset)
+
+Each repo has a unique offset to prevent conflicts when running test stacks in parallel:
+
+| Repo | Offset | Neo4j HTTP | Neo4j Bolt | Milvus gRPC | Milvus Health | API |
+|------|--------|------------|------------|-------------|---------------|-----|
+| hermes | +10000 | 17474 | 17687 | 29530 | 19091 | 18000 |
+| apollo | +20000 | 27474 | 27687 | 39530 | 29091 | 28000 |
+| logos | +30000 | 37474 | 37687 | 49530 | 39091 | 38000 |
+| sophia | +40000 | 47474 | 47687 | 59530 | 49091 | 48000 |
+| talos | +50000 | 57474 | 57687 | 69530 | 59091 | 58000 |
 
 ---
 

--- a/docs/TESTING_STANDARDS.md
+++ b/docs/TESTING_STANDARDS.md
@@ -85,12 +85,15 @@ def test_complete_workflow():
 
 Each repository uses a unique port offset to prevent conflicts when running multiple test stacks simultaneously.
 
-### Standard Offset (+10000 × alphabetical position)
+### Standard Offset (base + repo offset)
+
+Each repo has a unique offset to prevent conflicts when running test stacks in parallel.
+The single source of truth for these values is `logos_config.ports` in the logos-foundry package.
 
 | Repo | Offset | Neo4j HTTP | Neo4j Bolt | Milvus gRPC | Milvus Health | API |
 |------|--------|------------|------------|-------------|---------------|-----|
-| apollo | +10000 | 17474 | 17687 | 29530 | 19091 | 18000 |
-| hermes | +20000 | 27474 | 27687 | 39530 | 29091 | 28000 |
+| hermes | +10000 | 17474 | 17687 | 29530 | 19091 | 18000 |
+| apollo | +20000 | 27474 | 27687 | 39530 | 29091 | 28000 |
 | logos | +30000 | 37474 | 37687 | 49530 | 39091 | 38000 |
 | sophia | +40000 | 47474 | 47687 | 59530 | 49091 | 48000 |
 | talos | +50000 | 57474 | 57687 | 69530 | 59091 | 58000 |

--- a/infra/test_stack/repos.yaml
+++ b/infra/test_stack/repos.yaml
@@ -1,16 +1,19 @@
 # LOGOS Ecosystem Test Stack Configuration
 #
-# Port allocation standard: Each repo uses a consistent Nxxxx prefix for ALL ports
-#   hermes:  1xxxx  (h for 1)
-#   apollo:  2xxxx  (a for 2)
-#   logos:   3xxxx  (l for 3)
-#   sophia:  4xxxx  (s for 4)
-#   talos:   5xxxx  (t for 5)
+# Port allocation standard: base_port + repo_offset
+#   hermes:  +10000
+#   apollo:  +20000
+#   logos:   +30000
+#   sophia:  +40000
+#   talos:   +50000
 #
-# Base port patterns (replace leading digit with repo prefix):
-#   Neo4j HTTP: x7474, Bolt: x7687
-#   Milvus gRPC: x9530, Metrics: x9091
-#   MinIO API: x9000, Console: x9001
+# Base ports:
+#   Neo4j HTTP: 7474, Bolt: 7687
+#   Milvus gRPC: 19530, Metrics: 9091
+#   MinIO API: 9000, Console: 9001
+#   API: 8000
+#
+# See logos_config.ports for the single source of truth.
 
 defaults:
   compose_filename: docker-compose.test.yml
@@ -43,7 +46,7 @@ defaults:
     MILVUS_HEALTHCHECK: "http://milvus:{milvus_metrics_port}/healthz"
 
 repos:
-  # hermes: 1xxxx prefix (Milvus only, no Neo4j)
+  # hermes: +10000 offset (Milvus only, no Neo4j)
   hermes:
     path: ../hermes
     service_prefix: hermes-test
@@ -53,7 +56,7 @@ repos:
       - milvus-minio
       - milvus
     context:
-      milvus_grpc_port: "19530"
+      milvus_grpc_port: "29530"
       milvus_metrics_port: "19091"
       minio_api_port: "19000"
       minio_console_port: "19001"
@@ -61,7 +64,7 @@ repos:
       MILVUS_HOST: milvus
       MILVUS_PORT: "{milvus_grpc_port}"
 
-  # apollo: 2xxxx prefix
+  # apollo: +20000 offset
   apollo:
     path: ../apollo
     service_prefix: apollo-test
@@ -74,14 +77,14 @@ repos:
     context:
       neo4j_http_port: "27474"
       neo4j_bolt_port: "27687"
-      milvus_grpc_port: "29530"
+      milvus_grpc_port: "39530"
       milvus_metrics_port: "29091"
       minio_api_port: "29000"
       minio_console_port: "29001"
     env:
       NEO4J_URI: "bolt://neo4j:{neo4j_bolt_port}"
 
-  # logos: 3xxxx prefix
+  # logos: +30000 offset
   logos:
     path: .
     service_prefix: logos-test
@@ -95,14 +98,14 @@ repos:
     context:
       neo4j_http_port: "37474"
       neo4j_bolt_port: "37687"
-      milvus_grpc_port: "39530"
+      milvus_grpc_port: "49530"
       milvus_metrics_port: "39091"
       minio_api_port: "39000"
       minio_console_port: "39001"
     env:
       NEO4J_URI: "bolt://neo4j:{neo4j_bolt_port}"
 
-  # sophia: 4xxxx prefix
+  # sophia: +40000 offset
   sophia:
     path: ../sophia
     service_prefix: sophia-test
@@ -115,14 +118,14 @@ repos:
     context:
       neo4j_http_port: "47474"
       neo4j_bolt_port: "47687"
-      milvus_grpc_port: "49530"
+      milvus_grpc_port: "59530"
       milvus_metrics_port: "49091"
       minio_api_port: "49000"
       minio_console_port: "49001"
     env:
       NEO4J_URI: "bolt://neo4j:{neo4j_bolt_port}"
 
-  # talos: 5xxxx prefix
+  # talos: +50000 offset
   talos:
     path: ../talos
     service_prefix: talos-test
@@ -135,7 +138,7 @@ repos:
     context:
       neo4j_http_port: "57474"
       neo4j_bolt_port: "57687"
-      milvus_grpc_port: "59530"
+      milvus_grpc_port: "69530"
       milvus_metrics_port: "59091"
       minio_api_port: "59000"
       minio_console_port: "59001"

--- a/tests/e2e/stack/logos/.env.test
+++ b/tests/e2e/stack/logos/.env.test
@@ -12,7 +12,7 @@ NEO4J_CONTAINER=logos-phase2-test-neo4j
 
 # Milvus Configuration
 MILVUS_HOST=localhost
-MILVUS_PORT=39530
+MILVUS_PORT=49530
 MILVUS_METRICS_PORT=39091
 MILVUS_HEALTHCHECK=http://localhost:39091/healthz
 

--- a/tests/e2e/stack/logos/docker-compose.test.yml
+++ b/tests/e2e/stack/logos/docker-compose.test.yml
@@ -110,7 +110,7 @@ services:
     volumes:
     - logos_phase2_test_milvus:/var/lib/milvus
     ports:
-    - 39530:19530
+    - 49530:19530
     - 39091:9091
     healthcheck:
       test:

--- a/tests/phase2/docker-compose.test.yml
+++ b/tests/phase2/docker-compose.test.yml
@@ -13,8 +13,8 @@ services:
       - NEO4J_dbms_security_procedures_allowlist=apoc.*
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
     ports:
-      - "17687:7687"
-      - "17474:7474"
+      - "37687:7687"
+      - "37474:7474"
     volumes:
       - neo4j_test_data:/data
       - neo4j_test_logs:/logs
@@ -67,8 +67,8 @@ services:
     volumes:
       - milvus_test_data:/var/lib/milvus
     ports:
-      - "17530:19530"
-      - "17091:9091"
+      - "49530:19530"
+      - "39091:9091"
     depends_on:
       - milvus-etcd
       - milvus-minio


### PR DESCRIPTION
## Summary
Part of #433 - Port standardization across LOGOS repos

Updates logos test infrastructure to use consistent +30000 offset for all ports.

### Changes
- Updated `infra/test_stack/repos.yaml` with correct port values
- Updated `tests/e2e/stack/logos/docker-compose.test.yml`
- Updated `tests/phase2/docker-compose.test.yml`
- Updated `AGENTS.md` and `docs/TESTING_STANDARDS.md` with port tables

### Port Values
| Service | Port |
|---------|------|
| Neo4j HTTP | 37474 |
| Neo4j Bolt | 37687 |
| Milvus gRPC | 49530 |
| Milvus Metrics | 39091 |