### PR TITLE
[logos] Align CI/docs ports to logos_config (#449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         done
         echo "Waiting for Milvus..."
         for i in {1..90}; do
-          if curl -sf http://localhost:39091/healthz >/dev/null 2>&1; then
+          if curl -sf http://localhost:37091/healthz >/dev/null 2>&1; then
             echo "Milvus is ready"
             break
           fi
@@ -46,8 +46,8 @@ jobs:
         export NEO4J_PASSWORD=neo4jtest
         export NEO4J_CONTAINER=logos-phase2-test-neo4j
         export MILVUS_HOST=localhost
-        export MILVUS_PORT=39530
+        export MILVUS_PORT=37530
         echo "Initializing Milvus collections..."
-        poetry run python infra/init_milvus_collections.py --host localhost --port 39530 || echo "Milvus init failed (may already exist)"
+        poetry run python infra/init_milvus_collections.py --host localhost --port 37530 || echo "Milvus init failed (may already exist)"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/m1-neo4j-crud.yml
+++ b/.github/workflows/m1-neo4j-crud.yml
@@ -26,7 +26,7 @@ env:
   NEO4J_USER: neo4j
   NEO4J_PASSWORD: neo4jtest
   MILVUS_HOST: localhost
-  MILVUS_PORT: 39530
+  MILVUS_PORT: 37530
 
 jobs:
   m1-neo4j-crud:

--- a/.github/workflows/m4-end-to-end.yml
+++ b/.github/workflows/m4-end-to-end.yml
@@ -31,7 +31,7 @@ env:
   NEO4J_USER: neo4j
   NEO4J_PASSWORD: neo4jtest
   MILVUS_HOST: localhost
-  MILVUS_PORT: 39530
+  MILVUS_PORT: 37530
 
 jobs:
   e2e-prototype-test:

--- a/.github/workflows/phase2-e2e.yml
+++ b/.github/workflows/phase2-e2e.yml
@@ -80,7 +80,7 @@ jobs:
           echo "Checking minio:"
           docker logs logos-phase2-test-milvus-minio --tail=20 || true
           for i in {1..60}; do
-            if curl -f http://localhost:39091/healthz 2>/dev/null; then
+            if curl -f http://localhost:37091/healthz 2>/dev/null; then
               echo "Milvus is ready"
               exit 0
             fi
@@ -203,7 +203,7 @@ jobs:
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: neo4jtest
           MILVUS_HOST: localhost
-          MILVUS_PORT: 49530
+          MILVUS_PORT: 37530
           SOPHIA_API_KEY: test-ci-key
           HERMES_PORT: 8002
           APOLLO_PORT: 8003
@@ -220,7 +220,7 @@ jobs:
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: neo4jtest
           MILVUS_HOST: localhost
-          MILVUS_PORT: 49530
+          MILVUS_PORT: 37530
           SOPHIA_API_KEY: test-ci-key
       
       - name: Stop services
@@ -236,7 +236,7 @@ jobs:
           cat scripts/.pids/*.pid 2>/dev/null || echo "No PID files found"
           
           echo -e "\n=== Port status ==="
-          netstat -tlnp 2>/dev/null | grep -E ':(8001|8002|8003|37687|39530)' || echo "No services listening"
+          netstat -tlnp 2>/dev/null | grep -E ':(8001|8002|8003|37687|37530)' || echo "No services listening"
           
           echo -e "\n=== Neo4j logs ==="
           docker logs logos-phase2-test-neo4j --tail=100 || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,17 +50,17 @@ This repository defines the canonical standards for the entire LOGOS ecosystem. 
 | Git workflow | `docs/GIT_PROJECT_STANDARDS.md` |
 | Port allocation | `docs/TESTING_STANDARDS.md` (Port Allocation section) |
 
-### Port allocation (base + offset)
+### Port allocation (prefix-based)
 
-Each repo has a unique offset to prevent conflicts when running test stacks in parallel:
+Each repo has a unique prefix to prevent conflicts when running test stacks in parallel:
 
-| Repo | Offset | Neo4j HTTP | Neo4j Bolt | Milvus gRPC | Milvus Health | API |
+| Repo | Prefix | Neo4j HTTP | Neo4j Bolt | Milvus gRPC | Milvus Health | API |
 |------|--------|------------|------------|-------------|---------------|-----|
-| hermes | +10000 | 17474 | 17687 | 29530 | 19091 | 18000 |
-| apollo | +20000 | 27474 | 27687 | 39530 | 29091 | 28000 |
-| logos | +30000 | 37474 | 37687 | 49530 | 39091 | 38000 |
-| sophia | +40000 | 47474 | 47687 | 59530 | 49091 | 48000 |
-| talos | +50000 | 57474 | 57687 | 69530 | 59091 | 58000 |
+| hermes | 17xxx | 17474 | 17687 | 17530 | 17091 | 17000 |
+| apollo | 27xxx | 27474 | 27687 | 27530 | 27091 | 27000 |
+| logos | 37xxx | 37474 | 37687 | 37530 | 37091 | 37000 |
+| sophia | 47xxx | 47474 | 47687 | 47530 | 47091 | 47000 |
+| talos | 57xxx | 57474 | 57687 | 57530 | 57091 | 57000 |
 
 ### Shared configuration (`logos_config`)
 
@@ -402,7 +402,7 @@ Ensure environment variables match the port allocation:
 ```bash
 export NEO4J_URI=bolt://localhost:37687
 export MILVUS_HOST=localhost
-export MILVUS_PORT=49530
+export MILVUS_PORT=37530
 ```
 Or use `./scripts/run_tests.sh` which sets these automatically.
 
@@ -414,14 +414,14 @@ Or use `./scripts/run_tests.sh` which sets these automatically.
 ```
 
 ### Cross-repo changes: wrong ports
-Each repo has its own port offset. Check `docs/TESTING_STANDARDS.md` for the full table:
-| Repo | Offset |
+Each repo has its own port prefix. Check `docs/TESTING_STANDARDS.md` for the full table:
+| Repo | Prefix |
 |------|--------|
-| apollo | +10000 |
-| hermes | +20000 |
-| logos | +30000 |
-| sophia | +40000 |
-| talos | +50000 |
+| hermes | 17xxx |
+| apollo | 27xxx |
+| logos | 37xxx |
+| sophia | 47xxx |
+| talos | 57xxx |
 
 ### Import errors after pulling
 ```bash

--- a/docs/evidence/phase2/p2-m1/hermes_health.json
+++ b/docs/evidence/phase2/p2-m1/hermes_health.json
@@ -11,7 +11,7 @@
   "milvus": {
     "connected": false,
     "host": "localhost",
-    "port": "18530",
+    "port": "17530",
     "collection": null
   },
   "queue": {

--- a/docs/operations/TESTING.md
+++ b/docs/operations/TESTING.md
@@ -59,7 +59,7 @@ All Python repositories must use:
 | Location | `tests/integration/` or `tests/` with integration marker |
 
 **Infrastructure per repo:**
-- **Hermes:** `docker-compose.test.yml` (Milvus + Neo4j, ports 7687, 7474, 18530, 18091)
+- **Hermes:** `docker-compose.test.yml` (Milvus + Neo4j, ports 17687, 17474, 17530, 17091)
 - **Sophia:** Uses `logos/infra/docker-compose.hcg.dev.yml`
 - **Apollo:** `tests/e2e/docker-compose.e2e.yml` (Neo4j + mock services)
 - **Talos:** Uses shared infrastructure or skips if Neo4j unavailable
@@ -72,7 +72,7 @@ All Python repositories must use:
 
 **Infrastructure:** `logos/tests/e2e/stack/logos/docker-compose.test.yml` (managed via `tests/e2e/run_e2e.sh`)
 - Neo4j 5.14.0, Milvus 2.4.x (with etcd/MinIO)
-- Ports: 7687, 7474 (Neo4j), 8001 (Sophia), 8002 (Hermes), 8003 (Apollo), 18530, 18091 (Milvus)
+- Ports: 37687, 37474 (Neo4j), 8001 (Sophia), 8002 (Hermes), 8003 (Apollo), 37530, 37091 (Milvus)
 - Credentials: `neo4j/neo4jtest`, `SOPHIA_API_KEY=test-token-12345`
 
 **Run manually:**
@@ -218,13 +218,13 @@ HERMES_URL=http://localhost:8002
 APOLLO_URL=http://localhost:8003
 
 # Database connections
-NEO4J_URI=bolt://localhost:7687
+NEO4J_URI=bolt://localhost:37687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4jtest
 
 # Milvus
 MILVUS_HOST=localhost
-MILVUS_PORT=18530
+MILVUS_PORT=37530
 ```
 
 ---
@@ -233,7 +233,7 @@ MILVUS_PORT=18530
 
 ### Port Conflicts
 
-⚠️ Multiple test environments use the same ports (7687, 7474, 18530, 18091). Running tests from different repos simultaneously will fail.
+⚠️ Multiple Logos test environments use the same ports (37474, 37687, 37530, 37091). Running multiple Logos test stacks simultaneously will fail.
 
 **Workaround:** Run test suites sequentially.
 

--- a/docs/standards/TESTING_STANDARDS.md
+++ b/docs/standards/TESTING_STANDARDS.md
@@ -107,7 +107,7 @@ Each repo's test stack should set these automatically, but for manual runs:
 export NEO4J_URI=bolt://localhost:37687
 export NEO4J_HTTP=http://localhost:37474
 export MILVUS_HOST=localhost
-export MILVUS_PORT=49530
+export MILVUS_PORT=37530
 ```
 
 ---

--- a/logos_config/settings.py
+++ b/logos_config/settings.py
@@ -59,10 +59,10 @@ class MilvusConfig(BaseSettings):
         19530
 
         # With env vars set:
-        # MILVUS_PORT=29530
+        # MILVUS_PORT=37530
         >>> config = MilvusConfig()
         >>> config.port
-        29530
+        37530
     """
 
     model_config = SettingsConfigDict(env_prefix="MILVUS_")

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -51,6 +51,6 @@ poetry run render-test-stacks --repo logos
 The test stack includes:
 
 - **Neo4j 5.13.0** - Graph database (ports 7474, 7687)
-- **Milvus v2.4.15** - Vector database (ports 18530 gRPC, 18091 metrics)
+- **Milvus v2.4.15** - Vector database (ports 37530 gRPC, 37091 metrics)
   - etcd v3.5.15 - Milvus metadata store
   - MinIO - Milvus object storage (ports 9000, 9001)

--- a/tests/e2e/stack/logos/.env.test
+++ b/tests/e2e/stack/logos/.env.test
@@ -12,9 +12,9 @@ NEO4J_CONTAINER=logos-phase2-test-neo4j
 
 # Milvus Configuration
 MILVUS_HOST=localhost
-MILVUS_PORT=49530
-MILVUS_METRICS_PORT=39091
-MILVUS_HEALTHCHECK=http://localhost:39091/healthz
+MILVUS_PORT=37530
+MILVUS_METRICS_PORT=37091
+MILVUS_HEALTHCHECK=http://localhost:37091/healthz
 
 # MinIO Configuration
 MINIO_API_PORT=39000

--- a/tests/e2e/stack/logos/docker-compose.test.yml
+++ b/tests/e2e/stack/logos/docker-compose.test.yml
@@ -110,8 +110,8 @@ services:
     volumes:
     - logos_phase2_test_milvus:/var/lib/milvus
     ports:
-    - 49530:19530
-    - 39091:9091
+    - 37530:19530
+    - 37091:9091
     healthcheck:
       test:
       - CMD

--- a/tests/logos_config/test_settings.py
+++ b/tests/logos_config/test_settings.py
@@ -101,13 +101,13 @@ class TestMilvusConfig:
             os.environ,
             {
                 "MILVUS_HOST": "milvus-server",
-                "MILVUS_PORT": "29530",
+                "MILVUS_PORT": "37530",
                 "MILVUS_COLLECTION_NAME": "my_embeddings",
             },
         ):
             config = MilvusConfig()
             assert config.host == "milvus-server"
-            assert config.port == 29530
+            assert config.port == 37530
             assert config.collection_name == "my_embeddings"
 
 

--- a/tests/phase2/docker-compose.test.yml
+++ b/tests/phase2/docker-compose.test.yml
@@ -67,8 +67,8 @@ services:
     volumes:
       - milvus_test_data:/var/lib/milvus
     ports:
-      - "49530:19530"
-      - "39091:9091"
+      - "37530:19530"
+      - "37091:9091"
     depends_on:
       - milvus-etcd
       - milvus-minio


### PR DESCRIPTION
## Summary
Align Logos CI/test stack and documentation port references with `logos_config`.

Closes #449

## Changes
- Updated workflows and test stack configs to the 37xxx Milvus ports.
- Refreshed docs/evidence/examples to match the current port table.

## Testing
- Not run (documentation/CI config changes only)
