### PR TITLE
[logos] Add disk cleanup to reusable standard CI (#452)

### DIFF
--- a/.github/workflows/reusable-standard-ci.yml
+++ b/.github/workflows/reusable-standard-ci.yml
@@ -156,6 +156,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/*
+          sudo apt-get clean
+          sudo docker system prune -af
+          echo "Disk space after cleanup:"
+          df -h
+
       - name: Start test services
         if: inputs.docker_compose_file != ''
         run: |


### PR DESCRIPTION
## Summary
Add the same disk cleanup step used by reusable-publish to the reusable standard CI workflow to prevent out-of-space errors during docker pulls.

Closes #452

## Changes
- Added a pre-step to clear disk space before starting test services

## Testing
- Not run (workflow-only change)

## Downstream impact
All repos using `reusable-standard-ci.yml` will get the cleanup step.
