### PR TITLE
fix: use shared dev password for Neo4j HCG stack

### DIFF
--- a/infra/docker-compose.hcg.dev.yml
+++ b/infra/docker-compose.hcg.dev.yml
@@ -10,7 +10,7 @@ services:
       - "${NEO4J_HTTP_PORT:-7474}:7474"  # HTTP
       - "${NEO4J_BOLT_PORT:-7687}:7687"  # Bolt
     environment:
-      - NEO4J_AUTH=neo4j/neo4jtest
+      - NEO4J_AUTH=neo4j/logosdev
       - NEO4JLABS_PLUGINS=${NEO4JLABS_PLUGINS:-["apoc", "n10s"]}
       - NEO4J_dbms_security_procedures_unrestricted=apoc.*,n10s.*
       - NEO4J_dbms_security_procedures_allowlist=apoc.*,n10s.*
@@ -24,7 +24,7 @@ services:
       - logos-hcg-dev-net
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "neo4jtest", "RETURN 1"]
+      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "logosdev", "RETURN 1"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary
- Update Neo4j password in `infra/docker-compose.hcg.dev.yml` from `neo4jtest` to `logosdev`
- Local dev runs a shared Neo4j instance across repos, so credentials must be consistent

## Test plan
- [ ] Verify `docker compose -f infra/docker-compose.hcg.dev.yml up` starts Neo4j with new credentials
- [ ] Verify downstream repos can connect with `logosdev` password

🤖 Generated with [Claude Code](https://claude.com/claude-code)