### PR TITLE
fix: use env var for Neo4j password in test compose templates

### DIFF
--- a/infra/apollo/docker-compose.test.yml
+++ b/infra/apollo/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
     - 27474:7474
     - 27687:7687
     environment:
-    - NEO4J_AUTH=neo4j/neo4jtest
+    - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-logosdev}
     - NEO4J_PLUGINS=["apoc","n10s"]
     - NEO4JLABS_PLUGINS=["apoc","n10s"]
     - NEO4J_dbms_security_procedures_unrestricted=apoc.*,n10s.*
@@ -33,7 +33,7 @@ services:
       - -u
       - neo4j
       - -p
-      - neo4jtest
+      - ${NEO4J_PASSWORD:-logosdev}
       - RETURN 1
       interval: 10s
       timeout: 5s

--- a/infra/hermes/docker-compose.test.yml
+++ b/infra/hermes/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
     - 17474:7474
     - 17687:7687
     environment:
-    - NEO4J_AUTH=neo4j/neo4jtest
+    - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-logosdev}
     - NEO4J_PLUGINS=["apoc","n10s"]
     - NEO4JLABS_PLUGINS=["apoc","n10s"]
     - NEO4J_dbms_security_procedures_unrestricted=apoc.*,n10s.*
@@ -33,7 +33,7 @@ services:
       - -u
       - neo4j
       - -p
-      - neo4jtest
+      - ${NEO4J_PASSWORD:-logosdev}
       - RETURN 1
       interval: 10s
       timeout: 5s

--- a/infra/sophia/docker-compose.test.yml
+++ b/infra/sophia/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
     - 47474:7474
     - 47687:7687
     environment:
-    - NEO4J_AUTH=neo4j/neo4jtest
+    - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-logosdev}
     - NEO4J_PLUGINS=["apoc","n10s"]
     - NEO4JLABS_PLUGINS=["apoc","n10s"]
     - NEO4J_dbms_security_procedures_unrestricted=apoc.*,n10s.*
@@ -33,7 +33,7 @@ services:
       - -u
       - neo4j
       - -p
-      - neo4jtest
+      - ${NEO4J_PASSWORD:-logosdev}
       - RETURN 1
       interval: 10s
       timeout: 5s

--- a/infra/talos/docker-compose.test.yml
+++ b/infra/talos/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
     - 57474:7474
     - 57687:7687
     environment:
-    - NEO4J_AUTH=neo4j/neo4jtest
+    - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-logosdev}
     - NEO4J_PLUGINS=["apoc","n10s"]
     - NEO4JLABS_PLUGINS=["apoc","n10s"]
     - NEO4J_dbms_security_procedures_unrestricted=apoc.*,n10s.*
@@ -33,7 +33,7 @@ services:
       - -u
       - neo4j
       - -p
-      - neo4jtest
+      - ${NEO4J_PASSWORD:-logosdev}
       - RETURN 1
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
## Summary
- Update `infra/{apollo,sophia,hermes,talos}/docker-compose.test.yml` to use `${NEO4J_PASSWORD:-logosdev}` instead of hardcoded `neo4jtest` for both `NEO4J_AUTH` and healthcheck password
- These are the canonical templates that downstream repos copy — contributors can override via env var without modifying the compose files

## Note
- `tests/e2e/stack/` and `infra/test_stack/` also have hardcoded `neo4jtest` but those directories have `.env.test` files that supply it — updating those is a separate change
- Related: #480 (same pattern for `docker-compose.hcg.dev.yml`)

## Test plan
- [ ] Verify `docker compose config` renders correctly with default (no env var set)
- [ ] Verify `NEO4J_PASSWORD=custom docker compose config` overrides properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)