### PR TITLE
docs: proposed documentation refresh for LOGOS ecosystem

### DIFF
--- a/docs/proposed_docs/CI_CD.md
+++ b/docs/proposed_docs/CI_CD.md
@@ -12,12 +12,12 @@ Every LOGOS repo uses GitHub Actions with two types of workflows:
 Most repos delegate CI to a shared workflow in the logos repo:
 
 ```yaml
-uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@main
+uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@v0.4.1
 ```
 
 This provides:
 - Python setup (Poetry install, virtualenv caching)
-- Ruff lint + Black format check
+- Ruff lint + Black format check — CI currently runs both, but Ruff is the intended single tool going forward (see AGENTS.md). Black will be removed once all repos fully migrate to Ruff formatting.
 - mypy type checking
 - pytest execution
 - Optional Docker Compose for test infrastructure
@@ -132,7 +132,7 @@ Common causes:
 ### Container publish fails
 
 - Check that the Dockerfile builds locally: `docker build -t test .`
-- Verify the base image tag matches what's published (e.g., `logos-foundry:0.4.1`)
+- Verify the base image tag matches what's published (e.g., the Docker base image `ghcr.io/c-daly/logos-foundry:0.4.1` — this refers to the Docker image, not the Python package)
 - Check GHCR authentication (repo secrets)
 
 ## Useful Commands

--- a/docs/proposed_docs/DOC_MANIFEST.md
+++ b/docs/proposed_docs/DOC_MANIFEST.md
@@ -35,7 +35,7 @@ These are the authoritative references for cross-repo concerns. Every repo links
 
 | Item | Change |
 |------|--------|
-| `logos_config/README.md` | Fix wrong port example (59530), clarify shared infra |
+| `logos_config/README.md` | Fix wrong port example (59530), clarify shared infra. Note: this file also has offset-port confusion — it shows CI test-stack ports without clarifying they differ from local dev shared ports. |
 | `.github/workflows/phase1-gate.yml` | Rename to `gate-check.yml` or remove if unused |
 | `.github/workflows/phase2-e2e.yml` | Rename to `e2e-integration.yml` |
 | `.github/workflows/phase2-perception.yml` | Rename to `perception-tests.yml` |
@@ -75,7 +75,7 @@ Every repo should have exactly these files in its root:
 
 **apollo:**
 - Delete stale `.env.example` (has ports 8080/8082)
-- Fix `.env.test`: `NEO4J_URI=bolt://neo4j:27687` → `bolt://neo4j:7687`
+- Fix `.env.test`: `NEO4J_URI=bolt://neo4j:27687` → `bolt://neo4j:7687` (inside the Docker network, containers use service names and internal ports — not host-mapped offset ports)
 - Slim README.md
 - Remove phase references from `tests/e2e/test_e2e_flow.py` comment
 
@@ -88,12 +88,12 @@ Every repo should have exactly these files in its root:
 **hermes:**
 - Fix Dockerfile: base image `0.4.0` → `0.4.1`
 - Fix `.env.example`: `MILVUS_PORT=17530` → `19530`
-- Fix `.env.test`: `MILVUS_PORT=29530` (verify or fix)
+- Fix `.env.test`: `MILVUS_PORT=29530` → `19530` (shared port) or `17530` (hermes test offset). `29530` is incorrect — hermes prefix is 1xxxx, not 2xxxx.
 - Remove "Phase 2 Testing" from `tests/hermes/__init__.py` and `tests/README.md`
 - Slim README.md
 
 **talos:**
-- Fix README.md: remove `docker run -p 8002:8002` (Talos is a library, not a service)
+- Fix README.md: remove `docker run -p 8002:8002` (Talos is a Library / Service — it has a runtime for hardware abstraction, but the Docker example is stale)
 - Remove "Phase 1 simplification" comments from source code
 - Fix `docs/FIXTURES.md` circular reference
 

--- a/docs/proposed_docs/LOCAL_SETUP.md
+++ b/docs/proposed_docs/LOCAL_SETUP.md
@@ -9,7 +9,7 @@ Install these before starting:
 | Tool | Version | Install |
 |------|---------|---------|
 | Python | 3.11+ | `brew install python@3.11` |
-| Poetry | latest | `curl -sSL https://install.python-poetry.org \| python3 -` |
+| Poetry | latest | `brew install poetry` |
 | Node.js | 18+ | `brew install node@18` |
 | Docker | latest | [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/) |
 | Git | latest | `brew install git` |
@@ -87,14 +87,21 @@ cd ~/projects/LOGOS/apollo/webapp && npm ci
 
 ## Configure Environment
 
-Copy example env files:
+Copy example env files for each repo that has them:
 
 ```bash
+# Apollo
 cp ~/projects/LOGOS/apollo/.env.example ~/projects/LOGOS/apollo/.env
 cp ~/projects/LOGOS/apollo/webapp/.env.example ~/projects/LOGOS/apollo/webapp/.env
+
+# Sophia (if .env.example exists)
+cp ~/projects/LOGOS/sophia/.env.example ~/projects/LOGOS/sophia/.env 2>/dev/null || true
+
+# Hermes (if .env.example exists)
+cp ~/projects/LOGOS/hermes/.env.example ~/projects/LOGOS/hermes/.env 2>/dev/null || true
 ```
 
-The defaults connect to shared infrastructure on standard ports (Neo4j 7687, Milvus 19530). You shouldn't need to change anything for local dev.
+The defaults connect to shared infrastructure on standard ports (Neo4j 7687, Milvus 19530). You shouldn't need to change anything for local dev. Check each repo's `.env.example` for repo-specific settings (e.g., model paths for Hermes, cognitive core config for Sophia).
 
 ## Start Services
 

--- a/docs/proposed_docs/TESTING.md
+++ b/docs/proposed_docs/TESTING.md
@@ -36,18 +36,22 @@ Tests discover these services via `logos_config` defaults (Neo4j on 7687, Milvus
 
 ## Test Stacks (CI-style Isolation)
 
-Each repo has a `containers/docker-compose.test.yml` that spins up isolated infrastructure with repo-specific port offsets (see [ARCHITECTURE.md](ARCHITECTURE.md#port-scheme-shared-vs-test-isolation) for the port table).
+Each repo has test stack compose files that spin up isolated infrastructure with repo-specific port offsets (see [ARCHITECTURE.md](ARCHITECTURE.md#port-scheme-shared-vs-test-isolation) for the port table). The actual paths are:
+
+- `infra/test_stack/docker-compose.test.yml` — generated test stack
+- `tests/e2e/stack/logos/docker-compose.test.yml` — E2E stack
+- `infra/{repo}/docker-compose.test.yml` — per-repo stacks
 
 ```bash
-# Start test stack
-docker compose -f containers/docker-compose.test.yml up -d
+# Start test stack (example using generated test stack)
+docker compose -f infra/test_stack/docker-compose.test.yml up -d
 
 # Run tests against it (set env vars for offset ports)
 export NEO4J_URI=bolt://localhost:27687  # apollo example
 poetry run pytest tests/
 
 # Tear down
-docker compose -f containers/docker-compose.test.yml down -v
+docker compose -f infra/test_stack/docker-compose.test.yml down -v
 ```
 
 Some repos have overlay compose files (e.g., `docker-compose.test.apollo.yml`) that add service containers (sophia, hermes) on top of infrastructure.

--- a/docs/proposed_docs/WHY.md
+++ b/docs/proposed_docs/WHY.md
@@ -51,7 +51,9 @@ In CI, each repo spins up its *own* Neo4j and Milvus in Docker containers. If th
 |------|-------------------|----------|
 | hermes | 17687 | 7687 |
 | apollo | 27687 | 7687 |
+| logos | 37687 | 7687 |
 | sophia | 47687 | 7687 |
+| talos | 57687 | 7687 |
 
 Inside the containers, everything still uses 7687. The offset is only on the host side, in `docker-compose` port mappings. Your code should never hardcode offset ports — use `logos_config` or environment variables.
 


### PR DESCRIPTION
## Summary

- Adds 6 new proposed docs in `docs/proposed_docs/` to replace outdated, fragmented per-repo documentation
- **ARCHITECTURE.md** — system overview, dependency graph, local vs CI dependency consumption, port scheme
- **LOCAL_SETUP.md** — fresh machine setup guide (designed to be testable against a clean Mac)
- **WHY.md** — FAQ for new developers: why 5 repos, why Poetry, why two port schemes, etc.
- **DOC_MANIFEST.md** — inventory of all existing docs across repos with keep/kill/rename recommendations
- **TESTING.md** — testing strategy, running tests, infrastructure needs, linting
- **CI_CD.md** — how CI/CD works, reusable workflows, container publishing, debugging failures

## Context

A documentation audit across all 5 repos revealed systemic issues: port confusion, stale `.env` files, missing referenced docs (TESTING_STANDARDS.md, GIT_PROJECT_STANDARDS.md don't exist), and outdated phase references everywhere. Rather than patch the existing docs, these proposed replacements provide a single coherent source of truth.

These are placed in `docs/proposed_docs/` for review before replacing existing documentation.

## Test plan

- [ ] Review each doc for accuracy against current codebase
- [ ] Test LOCAL_SETUP.md against a fresh machine
- [ ] Verify port scheme documentation matches `logos_config/ports.py`
- [ ] Review DOC_MANIFEST.md recommendations for what to keep/kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)