### PR TITLE
Fix Milvus collection.load() hanging Sophia startup

### DIFF
--- a/tests/test_hcg_milvus_sync.py
+++ b/tests/test_hcg_milvus_sync.py
@@ -49,6 +49,7 @@ class TestHCGMilvusSync:
             alias="default",
             host="localhost",
             port="19530",
+            timeout=30.0,
         )
         assert sync._connected is True
         assert len(sync._collections) == 5


### PR DESCRIPTION
## Summary
- `HCGMilvusSync.connect()` called `collection.load()` with no timeout — if Milvus was slow or had corrupted state, the call blocked forever, preventing Sophia from starting and causing "connection refused" on all endpoints (including `/hcg/snapshot`)
- Added a configurable 30s default timeout to all Milvus operations (`connections.connect`, `collection.load` in both `connect()` and `ensure_collection()`)
- Individual collection load failures are now caught and logged as warnings — the collection is skipped rather than blocking the entire startup

## Test plan
- [x] All 20 `test_hcg_milvus_sync.py` tests pass
- [x] Verified Sophia starts successfully with clean Milvus
- [x] Verified `/hcg/snapshot` endpoint returns 200