### PR TITLE
fix(hcg): HCGMilvusSync upsert-by-uuid instead of insert-only

### DIFF
--- a/infra/init_milvus_collections.py
+++ b/infra/init_milvus_collections.py
@@ -187,6 +187,12 @@ def init_all_collections(
         "hcg_concept_embeddings",
         "hcg_state_embeddings",
         "hcg_process_embeddings",
+        # Edge and TypeCentroid were previously only bootstrapped lazily by
+        # HCGMilvusSync.ensure_collection() (under the old auto_id schema), so on
+        # an upgraded deployment they kept the stale PK. Create them here too so
+        # the init path produces all six with the uuid-PK schema (logos#533 review).
+        "hcg_edge_embeddings",
+        "hcg_type_centroids",
     ]
 
     collections = {}
@@ -210,6 +216,8 @@ def verify_collections() -> bool:
         "hcg_concept_embeddings",
         "hcg_state_embeddings",
         "hcg_process_embeddings",
+        "hcg_edge_embeddings",
+        "hcg_type_centroids",
     ]
 
     all_valid = True

--- a/logos_hcg/sync.py
+++ b/logos_hcg/sync.py
@@ -151,9 +151,18 @@ class HCGMilvusSync:
         if utility.has_collection(name, using=self.alias):
             return
 
+        # uuid is the primary key (auto_id=False) so that upsert() replaces an
+        # existing row keyed on the node UUID instead of appending a duplicate.
+        # Schema mirrors infra/init_milvus_collections.py so the write path and
+        # the read/classify/health paths agree on the collection layout.
         fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
-            FieldSchema(name="uuid", dtype=DataType.VARCHAR, max_length=64),
+            FieldSchema(
+                name="uuid",
+                dtype=DataType.VARCHAR,
+                max_length=256,
+                is_primary=True,
+                auto_id=False,
+            ),
             FieldSchema(
                 name="embedding", dtype=DataType.FLOAT_VECTOR, dim=_get_embedding_dim()
             ),
@@ -301,18 +310,17 @@ class HCGMilvusSync:
         collection = self._get_collection(node_type)
 
         try:
-            # Prepare data for insertion
-            # Milvus uses upsert based on primary key (uuid)
+            # uuid is the primary key (auto_id=False), so upsert() replaces the
+            # existing row for this uuid rather than appending a duplicate.
             timestamp = int(datetime.now(UTC).timestamp())
             data = [
-                [uuid_str],  # uuid
+                [uuid_str],  # uuid (primary key)
                 [embedding],  # embedding
                 [model],  # embedding_model
                 [timestamp],  # last_sync
             ]
 
-            # Upsert to Milvus (replaces if exists)
-            collection.insert(data)
+            collection.upsert(data)
             collection.flush()
 
             logger.info(f"Upserted embedding for {node_type} {uuid_str}")
@@ -361,8 +369,9 @@ class HCGMilvusSync:
 
             data = [uuids, vectors, models, timestamps]
 
-            # Batch insert
-            collection.insert(data)
+            # uuid is the primary key, so upsert() replaces any existing rows for
+            # these uuids rather than appending duplicates.
+            collection.upsert(data)
             collection.flush()
 
             logger.info(f"Batch upserted {len(embeddings)} embeddings for {node_type}")

--- a/logos_hcg/sync.py
+++ b/logos_hcg/sync.py
@@ -149,7 +149,24 @@ class HCGMilvusSync:
 
         name = COLLECTION_NAMES[node_type]
         if utility.has_collection(name, using=self.alias):
-            return
+            existing = Collection(name=name, using=self.alias)
+            primary = [
+                f for f in existing.schema.fields if getattr(f, "is_primary", False)
+            ]
+            if primary and primary[0].name == "uuid":
+                return
+            # A pre-existing collection on the old auto_id INT64 'id' primary key
+            # cannot be upserted by uuid (Milvus rejects upsert when auto_id=True),
+            # which would silently break update_centroid() and Edge upserts after
+            # upgrade. Data is regenerable, so drop and recreate with the uuid-PK
+            # schema below.
+            logger.warning(
+                "Collection %s has primary key %r, not 'uuid' -- dropping and "
+                "recreating with the uuid-PK schema.",
+                name,
+                primary[0].name if primary else None,
+            )
+            utility.drop_collection(name, using=self.alias)
 
         # uuid is the primary key (auto_id=False) so that upsert() replaces an
         # existing row keyed on the node UUID instead of appending a duplicate.

--- a/tests/integration/test_hcg_milvus_upsert.py
+++ b/tests/integration/test_hcg_milvus_upsert.py
@@ -1,0 +1,173 @@
+"""Integration tests for HCGMilvusSync upsert-by-uuid semantics.
+
+Regression coverage for c-daly/logos#528: ``HCGMilvusSync`` was insert-only
+and could not upsert by node uuid (the schema used an auto_id INT64 primary
+key with ``uuid`` as a plain VARCHAR field), so re-ingesting the same node
+appended a duplicate row instead of replacing it.
+
+These tests run against a live Milvus instance and assert that ingesting the
+same uuid twice leaves exactly ONE row for that uuid. The host/port are read
+from ``MILVUS_HOST`` / ``MILVUS_PORT`` (the isolated test stack uses
+localhost:47530); if Milvus is unavailable the tests are skipped.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid as uuid_module
+
+import pytest
+from pymilvus import connections, utility
+
+from logos_hcg import sync as sync_module
+from logos_hcg.sync import HCGMilvusSync
+
+MILVUS_HOST = os.getenv("MILVUS_HOST", "localhost")
+MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
+
+pytestmark = pytest.mark.integration
+
+
+def _milvus_available() -> bool:
+    """Return True if a live Milvus accepts a connection at the configured host."""
+    try:
+        connections.connect(alias="ac528_probe", host=MILVUS_HOST, port=MILVUS_PORT)
+        connections.disconnect("ac528_probe")
+        return True
+    except Exception:
+        return False
+
+
+requires_milvus = pytest.mark.skipif(
+    not _milvus_available(),
+    reason=f"Milvus is not available on {MILVUS_HOST}:{MILVUS_PORT}",
+)
+
+
+@pytest.fixture
+def upsert_collection_name(monkeypatch):
+    """Register a unique throwaway collection for the ``Entity`` node type.
+
+    Patches ``COLLECTION_NAMES`` so all of HCGMilvusSync's machinery
+    (ensure_collection / upsert / get / health) targets a per-test collection,
+    avoiding any clobber of the real ``hcg_*`` collections. Drops the
+    collection on teardown.
+    """
+    name = f"hcg_test_upsert_{uuid_module.uuid4().hex[:12]}"
+    patched = dict(sync_module.COLLECTION_NAMES)
+    patched["Entity"] = name
+    monkeypatch.setattr(sync_module, "COLLECTION_NAMES", patched)
+
+    yield name
+
+    # Teardown: drop the throwaway collection if it was created.
+    try:
+        connections.connect(alias="ac528_cleanup", host=MILVUS_HOST, port=MILVUS_PORT)
+        if utility.has_collection(name, using="ac528_cleanup"):
+            utility.drop_collection(name, using="ac528_cleanup")
+        connections.disconnect("ac528_cleanup")
+    except Exception:
+        pass
+
+
+@requires_milvus
+def test_reingest_same_uuid_yields_single_row(upsert_collection_name):
+    """Ingesting the same node twice must leave exactly ONE row for that uuid.
+
+    This is the core AC for #528: the old insert()-only path appended a second
+    row on re-ingest; a true upsert keyed on uuid replaces it.
+    """
+    dim = sync_module._get_embedding_dim()
+    node_uuid = str(uuid_module.uuid4())
+
+    with HCGMilvusSync(milvus_host=MILVUS_HOST, milvus_port=MILVUS_PORT) as sync:
+        sync.ensure_collection("Entity")
+
+        # First ingest.
+        sync.upsert_embedding(
+            node_type="Entity",
+            uuid=node_uuid,
+            embedding=[0.10] * dim,
+            model="model-v1",
+        )
+
+        # Re-ingest the SAME uuid with a different embedding + model.
+        sync.upsert_embedding(
+            node_type="Entity",
+            uuid=node_uuid,
+            embedding=[0.99] * dim,
+            model="model-v2",
+        )
+
+        collection = sync._get_collection("Entity")
+        collection.flush()
+
+        rows = collection.query(
+            expr=f'uuid == "{node_uuid}"',
+            output_fields=["uuid", "embedding_model"],
+        )
+
+    # Exactly one row for the uuid (would be two before the fix).
+    assert len(rows) == 1, f"expected exactly 1 row for uuid, got {len(rows)}"
+    assert rows[0]["uuid"] == node_uuid
+    # The surviving row reflects the most recent ingest (true replace, not append).
+    assert rows[0]["embedding_model"] == "model-v2"
+
+
+@requires_milvus
+def test_batch_reingest_same_uuids_yields_single_rows(upsert_collection_name):
+    """Batch re-ingest of the same uuids must not accumulate duplicate rows."""
+    dim = sync_module._get_embedding_dim()
+    uuid_a = str(uuid_module.uuid4())
+    uuid_b = str(uuid_module.uuid4())
+
+    with HCGMilvusSync(milvus_host=MILVUS_HOST, milvus_port=MILVUS_PORT) as sync:
+        sync.ensure_collection("Entity")
+
+        batch_v1 = [
+            {"uuid": uuid_a, "embedding": [0.1] * dim, "model": "m1"},
+            {"uuid": uuid_b, "embedding": [0.2] * dim, "model": "m1"},
+        ]
+        sync.batch_upsert_embeddings(node_type="Entity", embeddings=batch_v1)
+
+        batch_v2 = [
+            {"uuid": uuid_a, "embedding": [0.3] * dim, "model": "m2"},
+            {"uuid": uuid_b, "embedding": [0.4] * dim, "model": "m2"},
+        ]
+        sync.batch_upsert_embeddings(node_type="Entity", embeddings=batch_v2)
+
+        collection = sync._get_collection("Entity")
+        collection.flush()
+
+        uuid_list = f'"{uuid_a}", "{uuid_b}"'
+        rows = collection.query(
+            expr=f"uuid in [{uuid_list}]",
+            output_fields=["uuid", "embedding_model"],
+        )
+
+    # Two distinct uuids, one row each (four rows before the fix).
+    assert len(rows) == 2, f"expected 2 rows (one per uuid), got {len(rows)}"
+    by_uuid = {r["uuid"]: r["embedding_model"] for r in rows}
+    assert by_uuid == {uuid_a: "m2", uuid_b: "m2"}
+
+
+@requires_milvus
+def test_ensure_collection_uses_uuid_primary_key(upsert_collection_name):
+    """The created collection must key on ``uuid`` (no auto_id INT64 ``id`` PK).
+
+    Guards against schema divergence: the writer's schema must match the
+    read/health path's expected ``uuid``-keyed layout.
+    """
+    with HCGMilvusSync(milvus_host=MILVUS_HOST, milvus_port=MILVUS_PORT) as sync:
+        sync.ensure_collection("Entity")
+        collection = sync._get_collection("Entity")
+
+        schema = collection.schema
+        field_names = {f.name for f in schema.fields}
+        assert field_names == {"uuid", "embedding", "embedding_model", "last_sync"}
+        assert "id" not in field_names
+
+        primary = [f for f in schema.fields if f.is_primary]
+        assert len(primary) == 1
+        assert primary[0].name == "uuid"
+        assert primary[0].auto_id is False

--- a/tests/integration/test_hcg_milvus_upsert.py
+++ b/tests/integration/test_hcg_milvus_upsert.py
@@ -31,7 +31,11 @@ pytestmark = pytest.mark.integration
 def _milvus_available() -> bool:
     """Return True if a live Milvus accepts a connection at the configured host."""
     try:
-        connections.connect(alias="ac528_probe", host=MILVUS_HOST, port=MILVUS_PORT)
+        # Bounded so a silently-unreachable Milvus fails the import-time probe
+        # fast instead of blocking pytest collection for pymilvus's ~30s default.
+        connections.connect(
+            alias="ac528_probe", host=MILVUS_HOST, port=MILVUS_PORT, timeout=5
+        )
         connections.disconnect("ac528_probe")
         return True
     except Exception:

--- a/tests/test_hcg_milvus_sync.py
+++ b/tests/test_hcg_milvus_sync.py
@@ -121,8 +121,10 @@ class TestHCGMilvusSync:
             model=test_model,
         )
 
-        # Verify collection operations
-        mock_coll_instance.insert.assert_called_once()
+        # Verify collection operations: must be a true upsert (keyed on uuid),
+        # not insert() which would append a duplicate row on re-ingest.
+        mock_coll_instance.upsert.assert_called_once()
+        mock_coll_instance.insert.assert_not_called()
         mock_coll_instance.flush.assert_called_once()
 
         # Verify returned metadata
@@ -167,8 +169,9 @@ class TestHCGMilvusSync:
             embeddings=embeddings,
         )
 
-        # Verify batch operation
-        mock_coll_instance.insert.assert_called_once()
+        # Verify batch operation uses true upsert (keyed on uuid), not insert()
+        mock_coll_instance.upsert.assert_called_once()
+        mock_coll_instance.insert.assert_not_called()
         mock_coll_instance.flush.assert_called_once()
 
         # Verify metadata list

--- a/tests/test_hcg_milvus_sync.py
+++ b/tests/test_hcg_milvus_sync.py
@@ -39,6 +39,55 @@ class TestHCGMilvusSync:
     @patch("logos_hcg.sync.connections")
     @patch("logos_hcg.sync.utility")
     @patch("logos_hcg.sync.Collection")
+    def test_ensure_collection_recreates_on_old_pk_schema(
+        self, mock_collection, mock_utility, mock_connections
+    ):
+        """A pre-existing collection on the old auto_id 'id' PK is dropped+recreated.
+
+        Otherwise upsert() fails at runtime: Milvus rejects upsert on an
+        auto_id=True primary key (logos#533 review).
+        """
+        sync = HCGMilvusSync()
+        sync._connected = True
+        mock_utility.has_collection.return_value = True
+        old_pk = Mock()
+        old_pk.name = "id"
+        old_pk.is_primary = True
+        emb = Mock()
+        emb.name = "embedding"
+        emb.is_primary = False
+        existing = Mock()
+        existing.schema.fields = [old_pk, emb]
+        mock_collection.return_value = existing
+
+        sync.ensure_collection("Entity")
+
+        mock_utility.drop_collection.assert_called_once()
+
+    @patch("logos_hcg.sync.connections")
+    @patch("logos_hcg.sync.utility")
+    @patch("logos_hcg.sync.Collection")
+    def test_ensure_collection_keeps_matching_uuid_pk(
+        self, mock_collection, mock_utility, mock_connections
+    ):
+        """A collection already on the uuid PK is reused, not dropped."""
+        sync = HCGMilvusSync()
+        sync._connected = True
+        mock_utility.has_collection.return_value = True
+        uuid_pk = Mock()
+        uuid_pk.name = "uuid"
+        uuid_pk.is_primary = True
+        existing = Mock()
+        existing.schema.fields = [uuid_pk]
+        mock_collection.return_value = existing
+
+        sync.ensure_collection("Entity")
+
+        mock_utility.drop_collection.assert_not_called()
+
+    @patch("logos_hcg.sync.connections")
+    @patch("logos_hcg.sync.utility")
+    @patch("logos_hcg.sync.Collection")
     def test_connect_success(self, mock_collection, mock_utility, mock_connections):
         """Test successful connection to Milvus."""
         # Setup mocks


### PR DESCRIPTION
## Summary

`HCGMilvusSync` was insert-only and could not upsert by node uuid. The collection schema used an `auto_id` INT64 `id` primary key with `uuid` as a plain VARCHAR(64) field, and both `upsert_embedding` / `batch_upsert_embeddings` called `collection.insert()` (not `upsert`) — despite comments claiming upsert semantics. Re-ingesting the same node appended a duplicate row instead of replacing it, so the collection accumulated duplicate vectors per uuid and similarity search returned stale/duplicate hits.

## Changes

- **`logos_hcg/sync.py` `ensure_collection()`**: `uuid` is now the VARCHAR(256) primary key with `auto_id=False`; the `auto_id` INT64 `id` field is removed. This mirrors `infra/init_milvus_collections.py` and the integration-test `EXPECTED_FIELDS`, eliminating write/read schema divergence. (Collection *names* already came from the shared `COLLECTION_NAMES` map used by both the write path and `health_check` / `check_hcg_health.py`, so naming was already aligned.)
- **`upsert_embedding()` / `batch_upsert_embeddings()`**: now call `collection.upsert()` for true upsert semantics keyed on `uuid`.
- Removed the misleading `"upsert based on primary key (uuid)"` / `"replaces if exists"` comments that described behavior `insert()` never had.

## Tests

- Updated the two unit tests (`test_upsert_embedding_success`, `test_batch_upsert_embeddings`) to assert `upsert()` is called and `insert()` is not.
- Added **`tests/integration/test_hcg_milvus_upsert.py`** (live Milvus, `@pytest.mark.integration`, skips if Milvus unavailable):
  - `test_reingest_same_uuid_yields_single_row` — ingest the same uuid twice → exactly **one** row, reflecting the most recent ingest.
  - `test_batch_reingest_same_uuids_yields_single_rows` — batch re-ingest → one row per uuid.
  - `test_ensure_collection_uses_uuid_primary_key` — created collection keys on `uuid` (auto_id=False), no `id` field.

## Verification

- `pytest tests/test_hcg_milvus_sync.py` → 23 passed (unit, mocked).
- `pytest tests/integration/test_hcg_milvus_upsert.py` → 3 passed against **live Milvus** (isolated stack at `localhost:47530`). Throwaway collections are dropped in teardown (verified none leaked).
- `ruff check`, `black --check`, `mypy logos_hcg/sync.py` all clean.

Note: poetry env had to be pinned to Python 3.12 (`poetry env use python3.12`) — the default 3.14 env breaks `pymilvus`/protobuf import (`google._upb._message` metaclass error). The project targets `^3.12`.

Closes #528