### PR TITLE
test(ci): de-vacuum integration tests + run them in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,6 +69,9 @@ jobs:
             fi
             echo "Waiting for Milvus... ($i)"; sleep 2
           done
+          # Hard-fail if Milvus never became healthy (mirrors the Neo4j wait), so a
+          # never-ready Milvus surfaces here instead of later as a misleading vacuum.
+          curl -sf http://localhost:37091/healthz >/dev/null
 
       - name: Initialize Milvus collections
         run: |
@@ -98,10 +101,14 @@ jobs:
           fi
           summary="$(grep -E '^=.* (passed|failed|skipped|error)' pytest-integration.log | tail -1)"
           echo "pytest summary: ${summary:-<none>}"
-          if echo "$summary" | grep -qE '[0-9]+ passed'; then
-            echo "Integration tests executed (at least one passed)."
+          # The suite counts as executed if anything passed OR failed; only an
+          # all-skipped run (zero passed, zero failed) is the vacuum failure mode.
+          # A genuine test failure surfaces via the pytest step's own exit code --
+          # this guard must not mislabel "tests ran and failed" as "silently skipping".
+          if echo "$summary" | grep -qE '[1-9][0-9]* (passed|failed)'; then
+            echo "Integration tests executed against the live stack."
           else
-            echo "::error::No integration tests passed against the live stack -- the spine suite is silently skipping. See logos#529."
+            echo "::error::No integration tests executed (0 passed, 0 failed) -- the spine suite is silently skipping. See logos#529."
             exit 1
           fi
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,118 @@
+name: Integration Tests
+
+# De-vacuum guard (logos#529): the spine integration tests (Neo4j/Milvus
+# persistence, embedding writes) must actually execute against live services in
+# CI -- not silently skip. This workflow stands up the test stack, runs the
+# integration + infra suites, and FAILS if zero integration tests ran, so a
+# blanket-skip regression can never go green again.
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Point the test helpers at the compose stack started below.
+  NEO4J_CONTAINER: logos-phase2-test-neo4j
+  MILVUS_CONTAINER: logos-phase2-test-milvus
+  NEO4J_URI: bolt://localhost:37687
+  NEO4J_USER: neo4j
+  NEO4J_PASSWORD: neo4jtest
+  MILVUS_HOST: localhost
+  MILVUS_PORT: "37530"
+
+jobs:
+  integration:
+    name: Spine integration tests (live Neo4j + Milvus)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: poetry install --with dev,test
+
+      - name: Start test stack (Neo4j + Milvus)
+        run: docker compose -f tests/e2e/stack/logos/docker-compose.test.yml up -d
+
+      - name: Wait for Neo4j
+        run: |
+          for i in $(seq 1 60); do
+            if docker exec logos-phase2-test-neo4j cypher-shell -u neo4j -p neo4jtest "RETURN 1" >/dev/null 2>&1; then
+              echo "Neo4j is ready"; break
+            fi
+            echo "Waiting for Neo4j... ($i)"; sleep 2
+          done
+          docker exec logos-phase2-test-neo4j cypher-shell -u neo4j -p neo4jtest "RETURN 1 AS ok"
+
+      - name: Wait for Milvus
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:37091/healthz >/dev/null 2>&1; then
+              echo "Milvus is ready"; break
+            fi
+            echo "Waiting for Milvus... ($i)"; sleep 2
+          done
+
+      - name: Initialize Milvus collections
+        run: |
+          poetry run python infra/init_milvus_collections.py \
+            --host "$MILVUS_HOST" --port "$MILVUS_PORT" \
+            || echo "Milvus init failed (may already exist)"
+
+      - name: Run integration + infra tests
+        id: run
+        run: |
+          set -o pipefail
+          # -p no:cacheprovider keeps runs reproducible; --no-header for cleaner logs.
+          poetry run pytest \
+            tests/integration tests/infra tests/e2e/test_phase1_end_to_end.py \
+            -v -ra --tb=short \
+            | tee pytest-integration.log
+
+      - name: Assert integration tests actually executed (de-vacuum guard)
+        if: always()
+        run: |
+          # Fail the build if EVERY integration test skipped -- that is the
+          # exact "vacuum" failure mode this issue (logos#529) closes: the
+          # stack is up but the suite protects nothing.
+          if [ ! -f pytest-integration.log ]; then
+            echo "::error::pytest log missing; integration tests did not run"
+            exit 1
+          fi
+          summary="$(grep -E '^=.* (passed|failed|skipped|error)' pytest-integration.log | tail -1)"
+          echo "pytest summary: ${summary:-<none>}"
+          if echo "$summary" | grep -qE '[0-9]+ passed'; then
+            echo "Integration tests executed (at least one passed)."
+          else
+            echo "::error::No integration tests passed against the live stack -- the spine suite is silently skipping. See logos#529."
+            exit 1
+          fi
+
+      - name: Upload pytest log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-pytest-log
+          path: pytest-integration.log
+          retention-days: 14
+
+      - name: Tear down test stack
+        if: always()
+        run: docker compose -f tests/e2e/stack/logos/docker-compose.test.yml down -v || true

--- a/docs/TEST_SKIP_CONDITIONS.md
+++ b/docs/TEST_SKIP_CONDITIONS.md
@@ -1,0 +1,74 @@
+# Test Skip Conditions (logos)
+
+Tracking issue: **logos#529** — *de-vacuum integration tests + run them in CI.*
+
+This document records every module-scope skip in the `logos` test suite and
+*why* it exists. The rule (enforced by code review, not yet by lint) is:
+
+> No silent `pytest.mark.skip` at module scope without a reason. Integration
+> tests must gate on **service reachability**, not on a local Docker container
+> name — so they run wherever the service is reachable (CI compose, the shared
+> test stack, a remote stack) instead of silently skipping.
+
+## The de-vacuum fix
+
+Before this work, several spine integration/E2E modules gated on
+`is_container_running(config.container)` — i.e. `docker ps --filter name=...`.
+That is a *vacuum*: it skips the whole module whenever no **local** container
+matches the expected name, even if Neo4j/Milvus are perfectly reachable. The
+tests then "pass" by protecting nothing.
+
+The fix switches those gates to real connectivity probes:
+
+- `logos_test_utils.neo4j.is_neo4j_available()` — opens a Bolt session and runs
+  `RETURN 1`.
+- `logos_test_utils.milvus.is_milvus_available()` — opens a gRPC connection
+  (added in this change to mirror the Neo4j probe).
+
+`is_container_running()` / `is_milvus_running()` remain for orchestration code
+that genuinely needs to know about a *local* container, but are no longer used
+to gate test execution.
+
+## Module-scope skips and their reasons
+
+| File | Gate | Runs in CI? | Reason |
+|------|------|-------------|--------|
+| `tests/integration/ontology/test_neo4j_crud.py` | `is_neo4j_available()` | ✅ (Neo4j up in compose) | Needs a reachable Neo4j (Bolt + `docker exec cypher-shell` to load ontology). |
+| `tests/integration/ontology/test_shacl_neo4j_validation.py` | per-test `is_neo4j_available()` / n10s presence | ✅ | Needs Neo4j; some cases need the n10s plugin. |
+| `tests/integration/perception/test_simulation_service_integration.py` | per-test Neo4j readiness | ✅ | Needs Neo4j. |
+| `tests/integration/planning/test_planning_workflow.py` | `pytest.mark.skip` (unconditional) | ❌ (intentional) | Tests reference the **old type-label ontology**; must be rewritten for the flexible `:Node` model. Tracked as follow-up — not a connectivity skip. |
+| `tests/infra/test_milvus_collections.py` | `is_milvus_available()` | ✅ (Milvus up in compose) | Needs a reachable Milvus. Host/port now resolve from central config (was hardcoded `19530`). Contains the **keystone signal-check** (see below). |
+| `tests/infra/test_hcg_client.py` | per-test Neo4j readiness / ontology loaded | ✅ | Needs Neo4j + loaded core ontology for data-dependent cases. |
+| `tests/test_seeder_reified.py` · `test_queries_reified.py` · `test_edge_reification.py` | `is_neo4j_available()` | ✅ | HCG client → Neo4j persistence (reified IS_A edges). |
+| `tests/logos_events/test_event_bus.py` | `REDIS_AVAILABLE` | ⚠️ only if Redis present | Pub/sub event bus needs Redis. The logos CI compose currently brings up Neo4j + Milvus only; add Redis to exercise this in CI. |
+| `tests/e2e/test_phase1_end_to_end.py` | `is_neo4j_available()` **and** `is_milvus_available()` | ✅ | Full spine E2E; needs both Neo4j and Milvus. |
+| `tests/e2e/test_phase2_end_to_end.py` | `/health` reachability of app services | ❌ in logos CI (intentional) | Needs the **full app stack** (Sophia/Apollo/Hermes), which logos CI does not stand up. Runs in the cross-repo E2E environment. |
+| `tests/e2e/test_cognitive_loop_smoke.py` | `/health` of Hermes + Sophia | ❌ in logos CI (intentional) | Needs running Hermes + Sophia services. |
+
+Legend: ✅ executes in logos CI against the live compose stack · ❌ intentionally
+skipped in logos CI (documented reason) · ⚠️ runs only when the dependency is
+present.
+
+## CI wiring
+
+- `.github/workflows/ci.yml` (reusable standard CI) already starts the
+  `tests/e2e/stack/logos/docker-compose.test.yml` stack (Neo4j + Milvus),
+  initialises Milvus collections, and exports `NEO4J_*` / `MILVUS_*` so the
+  collected integration tests connect to live services rather than skipping.
+- `.github/workflows/integration-tests.yml` (added for #529) is a dedicated job
+  that stands up the same stack, runs `tests/integration`, `tests/infra`, and
+  the phase-1 spine E2E, and — critically — **fails the build if zero
+  integration tests passed**. That guard is what prevents the suite from
+  silently regressing back into a vacuum.
+
+## Signal check (keystone bug)
+
+The c-daly/sophia#146 class of bug is a *swallowed / failed embedding write* —
+an embedding insert that is caught-and-dropped or never flushed, so nothing is
+persisted but nothing fails either.
+
+`tests/infra/test_milvus_collections.py::TestMilvusIntegration::test_embedding_write_is_readable_by_uuid`
+guards against it: it writes a uniquely-keyed embedding, flushes, then reads it
+back **by primary key** via `collection.query(...)` and asserts exactly that row
+is present. A swallowed write leaves nothing to read back, so the test fails.
+This runs in CI whenever Milvus is reachable.

--- a/logos_test_utils/milvus.py
+++ b/logos_test_utils/milvus.py
@@ -67,7 +67,9 @@ def is_milvus_running(config: MilvusConfig | None = None) -> bool:
     return is_container_running(cfg.container)
 
 
-def is_milvus_available(config: MilvusConfig | None = None) -> bool:
+def is_milvus_available(
+    config: MilvusConfig | None = None, timeout: float = 2.0
+) -> bool:
     """Quick connectivity probe for Milvus.
 
     Unlike :func:`is_milvus_running`, which introspects a local Docker
@@ -84,7 +86,11 @@ def is_milvus_available(config: MilvusConfig | None = None) -> bool:
 
     alias = "logos_test_utils_probe"
     try:
-        connections.connect(alias=alias, host=cfg.host, port=str(cfg.port))
+        # Bounded so an unreachable/black-holed Milvus fails the probe fast
+        # instead of blocking test collection for pymilvus's ~20-30s default.
+        connections.connect(
+            alias=alias, host=cfg.host, port=str(cfg.port), timeout=timeout
+        )
     except Exception:
         return False
     else:

--- a/logos_test_utils/milvus.py
+++ b/logos_test_utils/milvus.py
@@ -67,6 +67,35 @@ def is_milvus_running(config: MilvusConfig | None = None) -> bool:
     return is_container_running(cfg.container)
 
 
+def is_milvus_available(config: MilvusConfig | None = None) -> bool:
+    """Quick connectivity probe for Milvus.
+
+    Unlike :func:`is_milvus_running`, which introspects a local Docker
+    container by name, this opens a real gRPC connection. Tests should gate on
+    *reachability* of the service (which works in CI compose, the shared test
+    stack, or a remote Milvus) rather than on a specific local container name.
+    """
+
+    cfg = config or get_milvus_config()
+    try:
+        from pymilvus import connections
+    except ImportError:
+        return False
+
+    alias = "logos_test_utils_probe"
+    try:
+        connections.connect(alias=alias, host=cfg.host, port=str(cfg.port))
+    except Exception:
+        return False
+    else:
+        return True
+    finally:
+        try:
+            connections.disconnect(alias)
+        except Exception:
+            pass
+
+
 def wait_for_milvus(config: MilvusConfig | None = None, timeout: int = 90) -> None:
     cfg = config or get_milvus_config()
     wait_for_container_health(cfg.container, timeout=timeout)

--- a/tests/e2e/test_phase1_end_to_end.py
+++ b/tests/e2e/test_phase1_end_to_end.py
@@ -26,14 +26,15 @@ from pathlib import Path
 
 import pytest
 
-from logos_test_utils.docker import is_container_running
 from logos_test_utils.env import get_repo_root, load_stack_env
 from logos_test_utils.milvus import (
     get_milvus_config,
+    is_milvus_available,
     wait_for_milvus,
 )
 from logos_test_utils.neo4j import (
     get_neo4j_config,
+    is_neo4j_available,
     wait_for_neo4j,
 )
 from logos_test_utils.neo4j import (
@@ -43,13 +44,26 @@ from logos_test_utils.neo4j import (
     run_cypher_query as stack_run_cypher_query,
 )
 
-# Load config early to check container availability
+# Load config early to check service availability.
 _STACK_ENV = load_stack_env()
 _NEO4J_CONFIG = get_neo4j_config(_STACK_ENV)
+_MILVUS_CONFIG = get_milvus_config(_STACK_ENV)
 
-if not is_container_running(_NEO4J_CONFIG.container):
+# Gate on actual service reachability (Bolt + Milvus gRPC), not on local
+# Docker container names. This lets the spine E2E run in CI compose, the shared
+# test stack, or against a remote stack instead of silently skipping.
+if not is_neo4j_available(_NEO4J_CONFIG):
     pytest.skip(
-        "Phase 1 E2E tests require Neo4j container. Start with: ./tests/e2e/run_e2e.sh up",
+        f"Phase 1 E2E tests require Neo4j (unreachable at {_NEO4J_CONFIG.uri}). "
+        "Start with: ./tests/e2e/run_e2e.sh up",
+        allow_module_level=True,
+    )
+
+if not is_milvus_available(_MILVUS_CONFIG):
+    pytest.skip(
+        "Phase 1 E2E tests require Milvus "
+        f"(unreachable at {_MILVUS_CONFIG.host}:{_MILVUS_CONFIG.port}). "
+        "Start with: ./tests/e2e/run_e2e.sh up",
         allow_module_level=True,
     )
 
@@ -64,7 +78,7 @@ except ImportError:
 STACK_ENV = _STACK_ENV
 REPO_ROOT = get_repo_root(STACK_ENV)
 NEO4J_CONFIG = _NEO4J_CONFIG
-MILVUS_CONFIG = get_milvus_config(STACK_ENV)
+MILVUS_CONFIG = _MILVUS_CONFIG
 NEO4J_WAIT_TIMEOUT = int(os.getenv("NEO4J_WAIT_TIMEOUT", "120"))
 MILVUS_WAIT_TIMEOUT = int(os.getenv("MILVUS_WAIT_TIMEOUT", "60"))
 

--- a/tests/infra/test_milvus_collections.py
+++ b/tests/infra/test_milvus_collections.py
@@ -9,10 +9,10 @@ configured via MILVUS_HOST and MILVUS_PORT environment variables.
 If Milvus is not available, tests will be skipped.
 """
 
-import os
-
 import pytest
 from pymilvus import Collection, MilvusException, connections, utility
+
+from logos_test_utils.milvus import get_milvus_config, is_milvus_available
 
 # Expected collections per Section 4.1 (Core Ontology)
 EXPECTED_COLLECTIONS = [
@@ -25,29 +25,20 @@ EXPECTED_COLLECTIONS = [
 # Expected schema fields
 EXPECTED_FIELDS = ["uuid", "embedding", "embedding_model", "last_sync"]
 
-# Test configuration - can be overridden with environment variables
-MILVUS_HOST = os.getenv("MILVUS_HOST", "localhost")
-MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
+# Resolve host/port from the central config (honours MILVUS_HOST / MILVUS_PORT
+# env overrides and the repo's default ports) instead of a hardcoded 19530,
+# so the suite targets whichever stack is actually configured.
+_MILVUS_CONFIG = get_milvus_config()
+MILVUS_HOST = _MILVUS_CONFIG.host
+MILVUS_PORT = str(_MILVUS_CONFIG.port)
 
 
-def _check_milvus_available():
-    """Check if Milvus is available for testing."""
-    try:
-        connections.connect(
-            alias="test_connection",
-            host=MILVUS_HOST,
-            port=MILVUS_PORT,
-        )
-        connections.disconnect("test_connection")
-        return True
-    except Exception:
-        return False
-
-
-# Skip all tests in this module if Milvus is not available
+# Skip all tests in this module if Milvus is not reachable. Gate on a real
+# gRPC connection rather than a Docker container name so the tests run against
+# CI compose, the shared stack, or a remote Milvus.
 pytestmark = pytest.mark.skipif(
-    not _check_milvus_available(),
-    reason=f"Milvus is not available on {MILVUS_HOST}:{MILVUS_PORT}",
+    not is_milvus_available(_MILVUS_CONFIG),
+    reason=f"Milvus is not reachable on {MILVUS_HOST}:{MILVUS_PORT}",
 )
 
 
@@ -243,3 +234,62 @@ class TestMilvusIntegration:
         # Clean up - delete the test entity
         collection.delete(f"uuid in ['{test_uuid}']")
         collection.flush()
+
+    def test_embedding_write_is_readable_by_uuid(self, milvus_connection):
+        """Signal check: a written embedding must be retrievable by its uuid.
+
+        This is the keystone regression guard for the c-daly/sophia#146 class
+        of bug -- an embedding write that is silently swallowed (caught and
+        dropped) or never flushed. Unlike ``num_entities > 0`` (collection
+        wide), this asserts the *specific* row we just wrote is present, so a
+        no-op/swallowed write fails the test instead of passing on pre-existing
+        rows.
+        """
+        import time
+
+        collection_name = "hcg_entity_embeddings"
+        if not utility.has_collection(collection_name):
+            pytest.skip(f"Collection {collection_name} not initialized")
+
+        collection = Collection(name=collection_name)
+        try:
+            collection.load(_async=False, _refresh=False)
+        except Exception as e:
+            pytest.skip(f"Could not load collection: {e}")
+
+        embedding_dim = None
+        for field in collection.schema.fields:
+            if field.name == "embedding":
+                embedding_dim = field.params["dim"]
+                break
+        assert embedding_dim is not None, "Could not determine embedding dimension"
+
+        test_uuid = f"signal-check-{int(time.time() * 1000)}"
+        test_embedding = [0.42] * embedding_dim
+        try:
+            collection.insert(
+                [
+                    [test_uuid],
+                    [test_embedding],
+                    ["signal-check-model"],
+                    [int(time.time())],
+                ]
+            )
+            # A flush is what actually persists the segment. A swallowed write
+            # (insert never reached, or exception caught and dropped upstream)
+            # leaves nothing to read back below.
+            collection.flush()
+
+            rows = collection.query(
+                expr=f"uuid in ['{test_uuid}']",
+                output_fields=["uuid", "embedding_model"],
+            )
+            assert len(rows) == 1, (
+                f"Embedding write for {test_uuid} was not persisted/readable "
+                f"(got {len(rows)} rows). This is the swallowed-write regression."
+            )
+            assert rows[0]["uuid"] == test_uuid
+            assert rows[0]["embedding_model"] == "signal-check-model"
+        finally:
+            collection.delete(f"uuid in ['{test_uuid}']")
+            collection.flush()

--- a/tests/infra/test_milvus_collections.py
+++ b/tests/infra/test_milvus_collections.py
@@ -9,6 +9,8 @@ configured via MILVUS_HOST and MILVUS_PORT environment variables.
 If Milvus is not available, tests will be skipped.
 """
 
+import time
+
 import pytest
 from pymilvus import Collection, MilvusException, connections, utility
 
@@ -177,7 +179,6 @@ class TestMilvusIntegration:
 
     def test_insert_and_search(self, milvus_connection):
         """Test basic insert and search operations."""
-        import time
 
         collection_name = "hcg_entity_embeddings"
         if not utility.has_collection(collection_name):
@@ -245,7 +246,6 @@ class TestMilvusIntegration:
         no-op/swallowed write fails the test instead of passing on pre-existing
         rows.
         """
-        import time
 
         collection_name = "hcg_entity_embeddings"
         if not utility.has_collection(collection_name):

--- a/tests/integration/ontology/test_neo4j_crud.py
+++ b/tests/integration/ontology/test_neo4j_crud.py
@@ -26,20 +26,25 @@ from uuid import uuid4
 import pytest
 from neo4j.exceptions import ClientError
 
-from logos_test_utils.docker import is_container_running
 from logos_test_utils.env import get_repo_root
 from logos_test_utils.neo4j import (
     get_neo4j_config,
     get_neo4j_driver,
+    is_neo4j_available,
     load_cypher_file,
 )
 
 NEO4J_CONFIG = get_neo4j_config()
 REPO_ROOT = get_repo_root()
 
-if not is_container_running(NEO4J_CONFIG.container):
+# Gate on actual Bolt reachability, not on a local Docker container name.
+# This lets the test run wherever Neo4j is reachable -- CI compose, the shared
+# test stack, or a remote instance -- instead of silently skipping when no
+# local container matches NEO4J_CONTAINER.
+if not is_neo4j_available(NEO4J_CONFIG):
     pytest.skip(
-        "Neo4j container not running. Start with: ./tests/e2e/run_e2e.sh up",
+        f"Neo4j not reachable at {NEO4J_CONFIG.uri}. "
+        "Start the stack with: ./tests/e2e/run_e2e.sh up",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
## What

De-vacuum the integration tests and ensure they actually execute in CI against live services, per the follow-through in #529.

The spine integration/E2E tests gated on `is_container_running(config.container)` — a `docker ps --filter name=...` introspection. That is the vacuum: it skips the whole module whenever no **local** container matches the expected name, even when Neo4j/Milvus are perfectly reachable. The tests then "pass" by protecting nothing.

## Changes

- **`logos_test_utils/milvus.py`** — add `is_milvus_available()` (real gRPC connectivity probe), mirroring the existing `is_neo4j_available()`.
- **Switch module-level skip gates to reachability probes** (not docker-name introspection), with descriptive skip reasons:
  - `tests/integration/ontology/test_neo4j_crud.py` (Neo4j)
  - `tests/e2e/test_phase1_end_to_end.py` (Neo4j **and** Milvus)
- **`tests/infra/test_milvus_collections.py`** — resolve host/port from the central config (was hardcoded `19530`, which made the entire module skip against any other stack) and gate on `is_milvus_available()`.
- **Keystone signal-check** — add `TestMilvusIntegration::test_embedding_write_is_readable_by_uuid`: writes a uniquely-keyed embedding, flushes, reads it back **by primary key**, and asserts the specific row persisted. This catches the c-daly/sophia#146 *swallowed/failed embedding write* — a collection-wide `num_entities > 0` would not.
- **`.github/workflows/integration-tests.yml`** (new) — stands up the compose stack, inits Milvus collections, runs `tests/integration` + `tests/infra` + phase-1 E2E against live services, and **fails the build if zero integration tests passed** (the de-vacuum guard that stops the suite silently regressing back into a vacuum).
- **`docs/TEST_SKIP_CONDITIONS.md`** (new) — documents every module-scope skip and why it exists (which run in CI, which are intentionally skipped, and the reason for each).

## Acceptance criteria

- [x] Integration tests assert real spine behavior and gate on **service reachability**, so they run in CI against live Neo4j/Milvus rather than behind docker-name skips.
- [x] Skip conditions documented — no silent module-scope skip without a reason (`docs/TEST_SKIP_CONDITIONS.md`).
- [x] Signal check: `test_embedding_write_is_readable_by_uuid` catches the swallowed/failed embedding write (c-daly/sophia#146 class).
- [x] CI wired: dedicated `integration-tests.yml` executes the suite and fails if integration tests all skip.

## Verification

- `ruff check` + `black --check` clean on all edited files.
- `is_milvus_available()` returns `False` cleanly when Milvus is unreachable (no exception leaks).
- Full-suite `pytest --collect-only` succeeds with no import/collection errors; edited modules skip at module level with the new descriptive reasons.
- **Live execution against the shared test stack could not be performed**: in this environment the stack (Neo4j 7687 / Milvus 47530 / Redis 46379) was not reachable (connection refused; only observability containers were running). The integration job in `integration-tests.yml` is expected to exercise the tests live in CI.

## Note on the prune PRs

Per #529, the five prune PRs were the precursor. **talos#59 remains open and was NOT merged** by this PR (left as-is intentionally). The logos prune (#527) is already merged into `main`.

Closes #529
