### PR TITLE
fix(#535): authoritative embedding-dim resolution in logos_config

### DIFF
--- a/logos_config/__init__.py
+++ b/logos_config/__init__.py
@@ -20,6 +20,11 @@ from logos_config.ports import (
     RepoPorts,
     get_repo_ports,
 )
+from logos_config.embedding import (
+    EmbeddingDimMismatch,
+    get_embedding_dim_override,
+    resolve_embedding_dim,
+)
 from logos_config.settings import (
     MilvusConfig,
     Neo4jConfig,
@@ -47,6 +52,10 @@ __all__ = [
     "OtelConfig",
     "RedisConfig",
     "ServiceConfig",
+    # embedding
+    "EmbeddingDimMismatch",
+    "get_embedding_dim_override",
+    "resolve_embedding_dim",
 ]
 
 __version__ = "0.1.0"

--- a/logos_config/embedding.py
+++ b/logos_config/embedding.py
@@ -1,0 +1,64 @@
+"""Authoritative embedding-dimension resolution for the LOGOS HCG.
+
+The embedding vector dimension is taken from the *measured* output of the running
+embedding provider — never a hardcoded constant. ``LOGOS_EMBEDDING_DIM`` is an
+optional override that is validated against the measured output; if they disagree
+the resolution fails loud rather than letting a provider/collection dimension
+mismatch silently drop embeddings (see logos#535).
+"""
+
+from __future__ import annotations
+
+from logos_config.env import get_env_value
+
+
+class EmbeddingDimMismatch(ValueError):
+    """Raised when an explicit override disagrees with the measured embedding output."""
+
+
+def resolve_embedding_dim(measured_dim: int, override: int | None = None) -> int:
+    """Resolve the authoritative embedding dimension.
+
+    Args:
+        measured_dim: the actual length of an embedding produced by the live
+            provider (ground truth).
+        override: optional explicit ``LOGOS_EMBEDDING_DIM``; must equal
+            ``measured_dim`` or an :class:`EmbeddingDimMismatch` is raised.
+
+    Returns:
+        The authoritative dimension (always the measured value).
+
+    Raises:
+        EmbeddingDimMismatch: if ``override`` is set and disagrees with
+            ``measured_dim`` (the provider did not deliver the requested size).
+    """
+    if override is not None and override != measured_dim:
+        raise EmbeddingDimMismatch(
+            f"LOGOS_EMBEDDING_DIM={override} but the embedding provider produced "
+            f"{measured_dim}-dim vectors. The override cannot be honored — either "
+            f"remove it (to use the provider's measured dimension) or fix the "
+            f"provider/model so it actually emits {override} dimensions."
+        )
+    return measured_dim
+
+
+def get_embedding_dim_override() -> int | None:
+    """Read the optional ``LOGOS_EMBEDDING_DIM`` override.
+
+    ``LOGOS_EMBEDDING_DIM`` — embedding vector dimension:
+
+    * **Leave UNSET (``None``)** → derive the dimension from the running
+      provider's *measured* output. This is the recommended default.
+    * **Set an explicit int** → force a provider that supports it (e.g. OpenAI
+      Matryoshka models) to a specific size. The override is validated against
+      the measured output (see :func:`resolve_embedding_dim`) and fails loud if
+      the provider can't deliver it.
+
+    There is intentionally **no hardcoded numeric default** — a wrong constant
+    silently drops embeddings (logos#535: a 1536-dim provider writing into a
+    384-dim collection).
+    """
+    raw = get_env_value("LOGOS_EMBEDDING_DIM", default=None)
+    if raw is None or str(raw).strip() == "":
+        return None
+    return int(raw)

--- a/tests/logos_config/test_embedding.py
+++ b/tests/logos_config/test_embedding.py
@@ -1,0 +1,43 @@
+"""Tests for logos_config embedding-dimension resolution.
+
+The embedding dimension must come from the *measured* provider output, never a
+hardcoded constant. An explicit override (LOGOS_EMBEDDING_DIM) is allowed but is
+validated against the measured output and fails loud on disagreement, so a
+provider/collection dimension mismatch can never silently drop embeddings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from logos_config.embedding import (
+    EmbeddingDimMismatch,
+    get_embedding_dim_override,
+    resolve_embedding_dim,
+)
+
+
+class TestResolveEmbeddingDim:
+    def test_uses_measured_dim_when_no_override(self) -> None:
+        """With no override, the provider's measured output is authoritative."""
+        assert resolve_embedding_dim(measured_dim=1536, override=None) == 1536
+
+    def test_rejects_override_that_disagrees_with_measured(self) -> None:
+        """An explicit override the provider can't deliver fails loud, never silent.
+
+        e.g. LOGOS_EMBEDDING_DIM=512 against a model hard-wired to 384.
+        """
+        with pytest.raises(EmbeddingDimMismatch):
+            resolve_embedding_dim(measured_dim=384, override=512)
+
+
+class TestEmbeddingDimOverride:
+    def test_none_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unset LOGOS_EMBEDDING_DIM resolves to None — no hardcoded default."""
+        monkeypatch.delenv("LOGOS_EMBEDDING_DIM", raising=False)
+        assert get_embedding_dim_override() is None
+
+    def test_int_when_explicitly_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicit LOGOS_EMBEDDING_DIM is read as an int override."""
+        monkeypatch.setenv("LOGOS_EMBEDDING_DIM", "1536")
+        assert get_embedding_dim_override() == 1536


### PR DESCRIPTION
Closes #541 (sub-ticket of the embedding-dim coherence epic #535).

Adds `logos_config.embedding`: `resolve_embedding_dim(measured, override)` (measured-authoritative; override validated → `EmbeddingDimMismatch`) + `get_embedding_dim_override()` (None default, documented config home, no hardcoded 384). TDD'd (4 tests).

Single source of truth consumed by hermes (c-daly/hermes#107) and HCGMilvusSync (#542).