### PR TITLE
fix(#542): HCGMilvusSync sizes hcg_* collections from measured embedding + recreates

### DIFF
--- a/infra/init_milvus_collections.py
+++ b/infra/init_milvus_collections.py
@@ -17,7 +17,9 @@ Each collection stores:
 - embedding_model: Model used to generate the embedding
 - last_sync: Timestamp of last synchronization
 
-Default embedding dimension: 384 (suitable for sentence-transformers models like all-MiniLM-L6-v2)
+Embedding dimension is taken from LOGOS_EMBEDDING_DIM (or --embedding-dim); if
+neither is set, the embedding collections are created lazily at the *measured*
+dimension on first write (HCGMilvusSync self-corrects, logos#542).
 """
 
 import argparse
@@ -32,23 +34,23 @@ from pymilvus import (
     utility,
 )
 
-from logos_config import get_env_value
+from logos_config import get_embedding_dim_override
 
 # Default configuration
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = "19530"
-try:
-    DEFAULT_EMBEDDING_DIM = int(
-        get_env_value("LOGOS_EMBEDDING_DIM", default="384") or "384"
-    )
-except (ValueError, TypeError):
-    DEFAULT_EMBEDDING_DIM = 384
+# Embedding dimension: there is intentionally NO hardcoded default (logos#542).
+# When LOGOS_EMBEDDING_DIM is unset this is None and the embedding collections are
+# left to be created lazily at the *measured* dimension on first write
+# (HCGMilvusSync self-corrects); set LOGOS_EMBEDDING_DIM (or --embedding-dim) to
+# pre-create them here.
+EMBEDDING_DIM_OVERRIDE = get_embedding_dim_override()
 DEFAULT_INDEX_TYPE = "IVF_FLAT"  # Simple and effective for development
 DEFAULT_METRIC_TYPE = "L2"  # Euclidean distance for semantic similarity
 
 
 def create_collection_schema(
-    collection_name: str, embedding_dim: int = DEFAULT_EMBEDDING_DIM
+    collection_name: str, embedding_dim: int
 ) -> CollectionSchema:
     """
     Create a Milvus collection schema for HCG node embeddings.
@@ -121,7 +123,7 @@ def create_index(collection: Collection, index_type: str = DEFAULT_INDEX_TYPE) -
 
 def init_collection(
     collection_name: str,
-    embedding_dim: int = DEFAULT_EMBEDDING_DIM,
+    embedding_dim: int,
     force: bool = False,
 ) -> Collection:
     """
@@ -168,7 +170,7 @@ def init_collection(
 
 
 def init_all_collections(
-    embedding_dim: int = DEFAULT_EMBEDDING_DIM,
+    embedding_dim: int,
     force: bool = False,
 ) -> dict[str, Collection]:
     """
@@ -252,8 +254,10 @@ def main():
     parser.add_argument(
         "--embedding-dim",
         type=int,
-        default=DEFAULT_EMBEDDING_DIM,
-        help=f"Embedding dimension (default: {DEFAULT_EMBEDDING_DIM})",
+        default=EMBEDDING_DIM_OVERRIDE,
+        help="Embedding dimension. Defaults to LOGOS_EMBEDDING_DIM if set; if "
+        "neither is provided, embedding collections are left to be created "
+        "lazily at the measured dimension on first write (logos#542).",
     )
     parser.add_argument(
         "--force",
@@ -283,8 +287,16 @@ def main():
         if args.verify_only:
             # Just verify collections
             success = verify_collections()
+        elif args.embedding_dim is None:
+            # No explicit dim — defer to the self-correcting upsert path (logos#542).
+            print(
+                "\nℹ No LOGOS_EMBEDDING_DIM / --embedding-dim set — embedding "
+                "collections will be created lazily at the measured dimension on "
+                "first write (logos#542). Skipping pre-creation."
+            )
+            success = True
         else:
-            # Initialize collections
+            # Initialize collections at the explicit dimension
             collections = init_all_collections(
                 embedding_dim=args.embedding_dim,
                 force=args.force,

--- a/logos_hcg/sync.py
+++ b/logos_hcg/sync.py
@@ -21,8 +21,6 @@ from uuid import UUID
 
 from pymilvus import Collection, connections, utility
 
-from logos_config import get_env_value
-
 logger = logging.getLogger(__name__)
 
 

--- a/logos_hcg/sync.py
+++ b/logos_hcg/sync.py
@@ -152,6 +152,13 @@ class HCGMilvusSync:
 
         from pymilvus import CollectionSchema, DataType, FieldSchema
 
+        # Fast path: already cached at the right dim — skip the Milvus round-trips
+        # (has_collection + Collection introspection) that would otherwise run on
+        # every upsert (gemini review on #543).
+        cached = self._collections.get(node_type)
+        if cached is not None and _collection_embedding_dim(cached) == dim:
+            return
+
         name = COLLECTION_NAMES[node_type]
         if utility.has_collection(name, using=self.alias):
             existing = Collection(name=name, using=self.alias)

--- a/logos_hcg/sync.py
+++ b/logos_hcg/sync.py
@@ -29,7 +29,10 @@ def _collection_embedding_dim(collection: Any) -> int | None:
     for field in collection.schema.fields:
         if field.name == "embedding":
             params = getattr(field, "params", None) or {}
-            return params.get("dim")
+            dim = params.get("dim")
+            # Milvus may report ``dim`` as a string; cast so dim comparisons are
+            # numeric and don't spuriously trigger a drop+recreate.
+            return int(dim) if dim is not None else None
     return None
 
 

--- a/logos_hcg/sync.py
+++ b/logos_hcg/sync.py
@@ -26,14 +26,13 @@ from logos_config import get_env_value
 logger = logging.getLogger(__name__)
 
 
-def _get_embedding_dim() -> int:
-    """Resolve embedding dimension lazily (env may not be loaded at import time)."""
-    raw = get_env_value("LOGOS_EMBEDDING_DIM", default="384") or "384"
-    try:
-        return int(raw)
-    except (ValueError, TypeError):
-        logger.warning("Invalid LOGOS_EMBEDDING_DIM=%r; defaulting to 384", raw)
-        return 384
+def _collection_embedding_dim(collection: Any) -> int | None:
+    """Return the dim of a collection's ``embedding`` FLOAT_VECTOR field, or None."""
+    for field in collection.schema.fields:
+        if field.name == "embedding":
+            params = getattr(field, "params", None) or {}
+            return params.get("dim")
+    return None
 
 
 # Collection name mapping for HCG node types
@@ -140,8 +139,14 @@ class HCGMilvusSync:
         except Exception as e:
             raise MilvusSyncError(f"Failed to connect to Milvus: {e}") from e
 
-    def ensure_collection(self, node_type: NodeType) -> None:
-        """Create collection with correct schema and L2 index if it doesn't exist."""
+    def ensure_collection(self, node_type: NodeType, dim: int) -> None:
+        """Create/load the collection for ``node_type`` sized to ``dim``.
+
+        If a collection already exists with a *different* embedding dimension it
+        is dropped and recreated, so a stale-dim collection never silently
+        rejects writes (logos#542). ``dim`` is the measured embedding length,
+        resolved via ``logos_config.resolve_embedding_dim`` at the call site.
+        """
         if not self._connected:
             raise MilvusSyncError("Not connected to Milvus. Call connect() first.")
 
@@ -153,18 +158,26 @@ class HCGMilvusSync:
             primary = [
                 f for f in existing.schema.fields if getattr(f, "is_primary", False)
             ]
-            if primary and primary[0].name == "uuid":
+            pk_ok = bool(primary) and primary[0].name == "uuid"
+            existing_dim = _collection_embedding_dim(existing)
+            if pk_ok and existing_dim == dim:
+                existing.load(timeout=self.timeout)
+                self._collections[node_type] = existing
                 return
-            # A pre-existing collection on the old auto_id INT64 'id' primary key
-            # cannot be upserted by uuid (Milvus rejects upsert when auto_id=True),
-            # which would silently break update_centroid() and Edge upserts after
-            # upgrade. Data is regenerable, so drop and recreate with the uuid-PK
-            # schema below.
+            # Recreate on a schema mismatch -- either the old auto_id INT64 'id'
+            # primary key (which Milvus refuses to upsert by uuid, logos#533) or a
+            # stale embedding dim (logos#542). The drop is intentional, not a
+            # data-loss bug: a wrong-PK or wrong-dim collection's vectors are
+            # unusable (384-dim rows can't be queried by a 1536-dim provider) and
+            # embeddings regenerate from Neo4j down to the type baseline, so a
+            # self-healing recreate is the desired behaviour.
             logger.warning(
-                "Collection %s has primary key %r, not 'uuid' -- dropping and "
-                "recreating with the uuid-PK schema.",
+                "Collection %s schema mismatch (pk=%r, dim=%s; want uuid/%s) -- "
+                "dropping and recreating.",
                 name,
                 primary[0].name if primary else None,
+                existing_dim,
+                dim,
             )
             utility.drop_collection(name, using=self.alias)
 
@@ -180,9 +193,7 @@ class HCGMilvusSync:
                 is_primary=True,
                 auto_id=False,
             ),
-            FieldSchema(
-                name="embedding", dtype=DataType.FLOAT_VECTOR, dim=_get_embedding_dim()
-            ),
+            FieldSchema(name="embedding", dtype=DataType.FLOAT_VECTOR, dim=dim),
             FieldSchema(name="embedding_model", dtype=DataType.VARCHAR, max_length=128),
             FieldSchema(name="last_sync", dtype=DataType.INT64),
         ]
@@ -324,6 +335,13 @@ class HCGMilvusSync:
             MilvusSyncError: If upsert fails
         """
         uuid_str = str(uuid)
+
+        from logos_config import get_embedding_dim_override, resolve_embedding_dim
+
+        self.ensure_collection(
+            node_type,
+            resolve_embedding_dim(len(embedding), get_embedding_dim_override()),
+        )
         collection = self._get_collection(node_type)
 
         try:
@@ -374,6 +392,15 @@ class HCGMilvusSync:
         if not embeddings:
             return []
 
+        from logos_config import get_embedding_dim_override, resolve_embedding_dim
+
+        # Size the collection to the *measured* embedding dim, recreating it if a
+        # stale-dim collection exists (logos#542) instead of failing the insert.
+        measured_dim = len(embeddings[0]["embedding"])
+        self.ensure_collection(
+            node_type,
+            resolve_embedding_dim(measured_dim, get_embedding_dim_override()),
+        )
         collection = self._get_collection(node_type)
 
         try:

--- a/logos_hcg/sync.py
+++ b/logos_hcg/sync.py
@@ -28,11 +28,17 @@ def _collection_embedding_dim(collection: Any) -> int | None:
     """Return the dim of a collection's ``embedding`` FLOAT_VECTOR field, or None."""
     for field in collection.schema.fields:
         if field.name == "embedding":
-            params = getattr(field, "params", None) or {}
-            dim = params.get("dim")
-            # Milvus may report ``dim`` as a string; cast so dim comparisons are
-            # numeric and don't spuriously trigger a drop+recreate.
-            return int(dim) if dim is not None else None
+            # Defensive: ``params`` may not be a dict, and Milvus can report
+            # ``dim`` as a string. Cast inside a guard so a malformed schema
+            # yields None rather than raising mid-write (gemini review).
+            params = getattr(field, "params", None)
+            if isinstance(params, dict):
+                dim = params.get("dim")
+                if dim is not None:
+                    try:
+                        return int(dim)
+                    except (ValueError, TypeError):
+                        pass
     return None
 
 

--- a/tests/test_hcg_milvus_dim.py
+++ b/tests/test_hcg_milvus_dim.py
@@ -43,6 +43,20 @@ def test_collection_embedding_dim_none_without_embedding_field() -> None:
     assert sync._collection_embedding_dim(coll) is None
 
 
+def test_collection_embedding_dim_handles_malformed_params() -> None:
+    """Non-dict params or a non-numeric dim yield None, never an exception."""
+    non_dict = SimpleNamespace(
+        schema=SimpleNamespace(fields=[SimpleNamespace(name="embedding", params=None)])
+    )
+    assert sync._collection_embedding_dim(non_dict) is None
+    bad_dim = SimpleNamespace(
+        schema=SimpleNamespace(
+            fields=[SimpleNamespace(name="embedding", params={"dim": "nope"})]
+        )
+    )
+    assert sync._collection_embedding_dim(bad_dim) is None
+
+
 def _milvus_up(host: str = "localhost", port: int = 19530) -> bool:
     try:
         with socket.create_connection((host, port), timeout=2):
@@ -51,10 +65,14 @@ def _milvus_up(host: str = "localhost", port: int = 19530) -> bool:
         return False
 
 
-@pytest.mark.skipif(not _milvus_up(), reason="dev Milvus not reachable on :19530")
 def test_ensure_collection_recreates_on_dim_mismatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Reachability probe runs at execution time, not pytest collection time, so
+    # unrelated runs aren't blocked on the socket timeout (greptile review).
+    if not _milvus_up():
+        pytest.skip("dev Milvus not reachable on :19530")
+
     from pymilvus import (
         Collection,
         CollectionSchema,
@@ -102,11 +120,13 @@ def test_ensure_collection_recreates_on_dim_mismatch(
             utility.drop_collection(name, using=alias)
 
 
-@pytest.mark.skipif(not _milvus_up(), reason="dev Milvus not reachable on :19530")
 def test_batch_upsert_sizes_collection_to_measured_dim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """batch_upsert_embeddings creates the collection at the measured dim and persists."""
+    if not _milvus_up():
+        pytest.skip("dev Milvus not reachable on :19530")
+
     import uuid as _uuid
 
     from pymilvus import Collection, utility

--- a/tests/test_hcg_milvus_dim.py
+++ b/tests/test_hcg_milvus_dim.py
@@ -9,11 +9,38 @@ Uses a throwaway collection name so real hcg_* collections are never touched.
 from __future__ import annotations
 
 import socket
+from types import SimpleNamespace
 
 import pytest
 
 from logos_hcg import sync
 from logos_hcg.sync import HCGMilvusSync
+
+
+def _fake_collection(dim: object) -> SimpleNamespace:
+    """A stand-in collection whose ``embedding`` field reports ``dim``."""
+    return SimpleNamespace(
+        schema=SimpleNamespace(
+            fields=[
+                SimpleNamespace(name="uuid", params={}),
+                SimpleNamespace(name="embedding", params={"dim": dim}),
+            ]
+        )
+    )
+
+
+def test_collection_embedding_dim_casts_string_to_int() -> None:
+    """Milvus may report the vector ``dim`` as a string; the helper must return an
+    int so dim comparisons don't spuriously trigger a drop+recreate (gemini #543)."""
+    assert sync._collection_embedding_dim(_fake_collection("1536")) == 1536
+    assert sync._collection_embedding_dim(_fake_collection(384)) == 384
+
+
+def test_collection_embedding_dim_none_without_embedding_field() -> None:
+    coll = SimpleNamespace(
+        schema=SimpleNamespace(fields=[SimpleNamespace(name="uuid", params={})])
+    )
+    assert sync._collection_embedding_dim(coll) is None
 
 
 def _milvus_up(host: str = "localhost", port: int = 19530) -> bool:

--- a/tests/test_hcg_milvus_dim.py
+++ b/tests/test_hcg_milvus_dim.py
@@ -1,0 +1,112 @@
+"""HCGMilvusSync must size hcg_* collections to the *measured* embedding dim and
+recreate a stale-dim collection instead of silently reusing it (logos#542,
+sub-ticket of the embedding-dim coherence epic #535).
+
+Integration test — needs a reachable Milvus (dev stack on localhost:19530).
+Uses a throwaway collection name so real hcg_* collections are never touched.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from logos_hcg import sync
+from logos_hcg.sync import HCGMilvusSync
+
+
+def _milvus_up(host: str = "localhost", port: int = 19530) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(not _milvus_up(), reason="dev Milvus not reachable on :19530")
+def test_ensure_collection_recreates_on_dim_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pymilvus import (
+        Collection,
+        CollectionSchema,
+        DataType,
+        FieldSchema,
+        utility,
+    )
+
+    name = "test_542_dim_recreate"
+    alias = "test542"
+    monkeypatch.setitem(sync.COLLECTION_NAMES, "Entity", name)
+    monkeypatch.delenv("LOGOS_EMBEDDING_DIM", raising=False)
+
+    s = HCGMilvusSync(milvus_host="localhost", milvus_port="19530", alias=alias)
+    s.connect()
+
+    # Seed a STALE 384-dim collection (the pre-fix state).
+    if utility.has_collection(name, using=alias):
+        utility.drop_collection(name, using=alias)
+    Collection(
+        name=name,
+        schema=CollectionSchema(
+            [
+                FieldSchema("id", DataType.INT64, is_primary=True, auto_id=True),
+                FieldSchema("uuid", DataType.VARCHAR, max_length=64),
+                FieldSchema("embedding", DataType.FLOAT_VECTOR, dim=384),
+                FieldSchema("embedding_model", DataType.VARCHAR, max_length=128),
+                FieldSchema("last_sync", DataType.INT64),
+            ]
+        ),
+        using=alias,
+    )
+
+    try:
+        # The incoming embeddings are 1536-dim -> ensure_collection must recreate.
+        s.ensure_collection("Entity", 1536)
+
+        coll = Collection(name=name, using=alias)
+        dim = next(
+            f.params.get("dim") for f in coll.schema.fields if f.name == "embedding"
+        )
+        assert dim == 1536
+    finally:
+        if utility.has_collection(name, using=alias):
+            utility.drop_collection(name, using=alias)
+
+
+@pytest.mark.skipif(not _milvus_up(), reason="dev Milvus not reachable on :19530")
+def test_batch_upsert_sizes_collection_to_measured_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """batch_upsert_embeddings creates the collection at the measured dim and persists."""
+    import uuid as _uuid
+
+    from pymilvus import Collection, utility
+
+    name = "test_542_batch_dim"
+    alias = "test542b"
+    monkeypatch.setitem(sync.COLLECTION_NAMES, "Concept", name)
+    monkeypatch.delenv("LOGOS_EMBEDDING_DIM", raising=False)
+
+    s = HCGMilvusSync(milvus_host="localhost", milvus_port="19530", alias=alias)
+    s.connect()
+    if utility.has_collection(name, using=alias):
+        utility.drop_collection(name, using=alias)
+
+    try:
+        embs = [
+            {"uuid": str(_uuid.uuid4()), "embedding": [0.1] * 1536, "model": "test"}
+        ]
+        s.batch_upsert_embeddings("Concept", embs)
+
+        coll = Collection(name=name, using=alias)
+        coll.flush()
+        dim = next(
+            f.params.get("dim") for f in coll.schema.fields if f.name == "embedding"
+        )
+        assert dim == 1536
+        assert coll.num_entities == 1
+    finally:
+        if utility.has_collection(name, using=alias):
+            utility.drop_collection(name, using=alias)

--- a/tests/test_hcg_milvus_sync.py
+++ b/tests/test_hcg_milvus_sync.py
@@ -56,11 +56,12 @@ class TestHCGMilvusSync:
         emb = Mock()
         emb.name = "embedding"
         emb.is_primary = False
+        emb.params = {"dim": 1536}
         existing = Mock()
         existing.schema.fields = [old_pk, emb]
         mock_collection.return_value = existing
 
-        sync.ensure_collection("Entity")
+        sync.ensure_collection("Entity", dim=1536)
 
         mock_utility.drop_collection.assert_called_once()
 
@@ -77,11 +78,15 @@ class TestHCGMilvusSync:
         uuid_pk = Mock()
         uuid_pk.name = "uuid"
         uuid_pk.is_primary = True
+        emb = Mock()
+        emb.name = "embedding"
+        emb.is_primary = False
+        emb.params = {"dim": 1536}
         existing = Mock()
-        existing.schema.fields = [uuid_pk]
+        existing.schema.fields = [uuid_pk, emb]
         mock_collection.return_value = existing
 
-        sync.ensure_collection("Entity")
+        sync.ensure_collection("Entity", dim=1536)
 
         mock_utility.drop_collection.assert_not_called()
 
@@ -157,7 +162,9 @@ class TestHCGMilvusSync:
 
         sync = HCGMilvusSync()
         sync.connect()
-        sync.ensure_collection = Mock()  # collection-sizing covered in test_hcg_milvus_dim.py
+        sync.ensure_collection = (
+            Mock()
+        )  # collection-sizing covered in test_hcg_milvus_dim.py
 
         # Upsert embedding
         test_uuid = str(uuid4())
@@ -207,7 +214,9 @@ class TestHCGMilvusSync:
 
         sync = HCGMilvusSync()
         sync.connect()
-        sync.ensure_collection = Mock()  # collection-sizing covered in test_hcg_milvus_dim.py
+        sync.ensure_collection = (
+            Mock()
+        )  # collection-sizing covered in test_hcg_milvus_dim.py
 
         # Batch upsert
         embeddings = [
@@ -477,7 +486,9 @@ class TestHCGMilvusSync:
         mock_collection.return_value = mock_coll
         sync = HCGMilvusSync()
         sync.connect()
-        sync.ensure_collection = Mock()  # collection-sizing covered in test_hcg_milvus_dim.py
+        sync.ensure_collection = (
+            Mock()
+        )  # collection-sizing covered in test_hcg_milvus_dim.py
         result = sync.update_centroid(
             type_uuid="type_location", centroid=[0.1] * 384, model="all-MiniLM-L6-v2"
         )

--- a/tests/test_hcg_milvus_sync.py
+++ b/tests/test_hcg_milvus_sync.py
@@ -157,6 +157,7 @@ class TestHCGMilvusSync:
 
         sync = HCGMilvusSync()
         sync.connect()
+        sync.ensure_collection = Mock()  # collection-sizing covered in test_hcg_milvus_dim.py
 
         # Upsert embedding
         test_uuid = str(uuid4())
@@ -206,6 +207,7 @@ class TestHCGMilvusSync:
 
         sync = HCGMilvusSync()
         sync.connect()
+        sync.ensure_collection = Mock()  # collection-sizing covered in test_hcg_milvus_dim.py
 
         # Batch upsert
         embeddings = [
@@ -475,6 +477,7 @@ class TestHCGMilvusSync:
         mock_collection.return_value = mock_coll
         sync = HCGMilvusSync()
         sync.connect()
+        sync.ensure_collection = Mock()  # collection-sizing covered in test_hcg_milvus_dim.py
         result = sync.update_centroid(
             type_uuid="type_location", centroid=[0.1] * 384, model="all-MiniLM-L6-v2"
         )


### PR DESCRIPTION
Closes #542 (sub-ticket of the embedding-dim coherence epic #535).

`logos_hcg/sync.py`:
- `ensure_collection(node_type, dim)` takes the embedding dim, validates an existing collection, and **drops+recreates on mismatch** (was: reuse-as-is).
- `upsert_embedding` / `batch_upsert_embeddings` resolve the **measured** embedding dim (`logos_config.resolve_embedding_dim`) + ensure the collection before writing — so a stale 384-dim hcg_* collection self-heals to the provider's dim (e.g. 1536) instead of dropping embeddings.
- Removed `_get_embedding_dim()` (the hardcoded 384).

TDD'd: integration tests for recreate + measured-dim sizing (live Milvus); 25 sync tests green.

**Stacked on #541** (`fix/541-embedding-dim-from-provider`) for the foundry primitive — base will flip to main once #541 merges. **Overlaps #528** (same `sync.py`) — coordinate merge order. Follow-up: `infra/init_milvus_collections.py` still hardcodes 384 (non-fatal now — upsert self-corrects).