### PR TITLE
docs: drop co-author exception from attribution rule

### DIFF
--- a/docs/GIT_PROJECT_STANDARDS.md
+++ b/docs/GIT_PROJECT_STANDARDS.md
@@ -63,7 +63,7 @@ docs/fix-readme-links
 - First line under 72 characters
 - One logical change per commit
 - No emoji in commit messages
-- No attribution lines except `Co-Authored-By` when applicable
+- No attribution lines of any kind — no agent/tool attribution, no `Co-Authored-By`
 
 ---
 

--- a/docs/GIT_PROJECT_STANDARDS.md
+++ b/docs/GIT_PROJECT_STANDARDS.md
@@ -63,7 +63,7 @@ docs/fix-readme-links
 - First line under 72 characters
 - One logical change per commit
 - No emoji in commit messages
-- No attribution lines of any kind — no agent/tool attribution, no `Co-Authored-By`
+- No attribution lines of any kind — no agent/tool attribution, no `Co-authored-by`
 
 ---
 


### PR DESCRIPTION
`docs/GIT_PROJECT_STANDARDS.md` (Commit Messages → Rules) stated:

> - No attribution lines except `Co-Authored-By` when applicable

The actual standard is **no attribution of any kind** — no agent/tool attribution and no co-author trailers. The `except` clause was incorrect and actively misled tooling into adding attribution. Updated line 66 to:

> - No attribution lines of any kind — no agent/tool attribution, no `Co-Authored-By`

Docs-only, one line. Do not merge without review.