### PR TITLE
chore(infra): add redis as a managed compose service

### DIFF
--- a/infra/docker-compose.hcg.dev.yml
+++ b/infra/docker-compose.hcg.dev.yml
@@ -69,7 +69,11 @@ services:
     image: redis:7-alpine
     container_name: logos-hcg-redis
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      # Loopback only: services reach Redis via localhost:6379 and other
+      # containers via the docker-network name; Redis is unauthenticated and
+      # holds the proposal queue / EventBus topics, so don't expose it on all
+      # host interfaces.
+      - "127.0.0.1:${REDIS_PORT:-6379}:6379"
     # Append-only persistence so the proposal queue / context cache survive a
     # container restart (the queue is drained by sophia's ProposalWorker).
     command: ["redis-server", "--appendonly", "yes"]

--- a/infra/docker-compose.hcg.dev.yml
+++ b/infra/docker-compose.hcg.dev.yml
@@ -65,6 +65,26 @@ services:
       retries: 3
       start_period: 10s
 
+  redis:
+    image: redis:7-alpine
+    container_name: logos-hcg-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    # Append-only persistence so the proposal queue / context cache survive a
+    # container restart (the queue is drained by sophia's ProposalWorker).
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    networks:
+      - logos-hcg-dev-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
 networks:
   logos-hcg-dev-net:
     driver: bridge
@@ -74,3 +94,4 @@ volumes:
   neo4j-logs:
   neo4j-plugins:
   milvus-data:
+  redis-data:


### PR DESCRIPTION
## What
Add `redis` to `infra/docker-compose.hcg.dev.yml` as a managed service (image `redis:7-alpine`, append-only persistence on a named `redis-data` volume, the shared `logos-hcg-dev-net` network, a `redis-cli ping` healthcheck, and `restart: unless-stopped`).

## Why
Redis backs the proposal queue / context cache and the EventBus pub/sub, but was previously run ad-hoc (`docker run`, `restart=no`, default bridge network) and wasn't in any compose file. A host/Docker restart left it down with no restart policy, which silently broke the cognitive-loop cache pipeline — every chat turn fell back to the slow synchronous path and complex messages timed out.

## Verification
Migrated the running stack to the compose-managed container: `PONG`, on `infra_logos-hcg-dev-net`, `restart=unless-stopped`, persistent `infra_redis-data` volume. Sophia + hermes reconnect via `localhost:6379`.