### PR TITLE
feat(hcg): seed 'process' as a domain realm root + bump foundry to v0.7.3

### DIFF
--- a/logos_hcg/seeder.py
+++ b/logos_hcg/seeder.py
@@ -40,6 +40,7 @@ TYPE_PARENTS: dict[str, str] = {
     "entity": "node",
     "concept": "node",
     "cognition": "node",
+    "process": "node",
     "reserved_node": "node",
     # Domain types under entity
     "object": "entity",
@@ -215,6 +216,11 @@ class HCGSeeder:
             "location": (
                 "A named place, workspace, or spatial region where objects "
                 "reside. Examples: table, shelf, bin, assembly station, tray."
+            ),
+            "process": (
+                "A real-world process, event, or activity that unfolds over "
+                "time. Examples: photosynthesis, combustion, evaporation, "
+                "digestion, erosion, oxidation."
             ),
             "reserved_agent": (
                 "An autonomous actor that perceives, decides, and acts. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "logos-foundry"
-version = "0.7.2"
+version = "0.7.3"
 description = "LOGOS Foundry - Canonical source of truth for Project LOGOS specifications, ontology, and infrastructure"
 readme = "README.md"
 authors = ["Project LOGOS Contributors"]


### PR DESCRIPTION
Seed a domain `process` root under `node` (sibling of entity/concept/cognition) with its own centroid description, so emergent process-types can root under it instead of folding into `entity`. Bumps foundry 0.7.2 -> 0.7.3.

**A super-type's `parent` is mandatory, not optional.** These realm roots are what make that guarantee possible: the rollup roots every top-level super-type under the realm it belongs to (concept / process / entity) and the realm chain flows down to the leaves, so a type is never left rootless and never *optionally* folds into the `entity` junk-drawer for lack of a home. Seeding `process` gives process-like clusters a correct mandatory parent instead of defaulting to `entity`. (The `/name-cluster` graft-parent field is nullable only for the *reuse* case — where an existing type is reconciled and nothing new is minted, so there is nothing to graft.)

Part of the reuse-or-graft typing design (docs/plans/2026-06-04-surprisal-driven-typing-and-metacognition.md). Tagged v0.7.3 for the downstream pins in sophia/hermes.

Part of #499.
