### PR TITLE
fix(hcg): seeder.clear() preserves Milvus collections by default (#559)

### DIFF
--- a/logos_hcg/seeder.py
+++ b/logos_hcg/seeder.py
@@ -90,19 +90,26 @@ class HCGSeeder:
     # clear
     # ------------------------------------------------------------------
 
-    def clear(self) -> None:
-        """Remove all seeded data from every store.
+    def clear(self, drop_collections: bool = False) -> None:
+        """Remove all seeded data; preserve the Milvus collections by default.
 
         Wipes the Neo4j graph and, where reachable, the Redis ontology keys
-        (``logos:ontology:*``) and the Milvus ``hcg_*`` collections, so a fresh
-        seed starts from a clean slate across the whole stack (logos#554).
+        (``logos:ontology:*``). The Milvus ``hcg_*`` collections are PRESERVED
+        (kept created, indexed and loaded) so a routine reseed stays seamless --
+        dropping them leaves them unloaded after the lazy re-create on next
+        ingest, which surfaces as "collection not loaded" search failures
+        (logos#559, a #515 regression). Pass ``drop_collections=True`` ONLY when
+        the embedding type/dimension changes and the collections must be rebuilt
+        (or use ``init_milvus_collections.py --force``, which also re-indexes and
+        re-loads them).
 
         A store that is unreachable is skipped with a warning; a store that is
         reachable but fails to clear raises, so partial wipes are never silent.
         """
         self.client.clear_all()
         self._clear_redis_ontology()
-        self._clear_milvus_collections()
+        if drop_collections:
+            self._clear_milvus_collections()
 
     @staticmethod
     def _clear_redis_ontology() -> None:
@@ -989,6 +996,13 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Only seed type definitions (no demo data or persona entries)",
     )
+    parser.add_argument(
+        "--drop-collections",
+        action="store_true",
+        help="Also DROP the Milvus hcg_* collections during --clear. Use only "
+        "when the embedding type/dimension changed; a routine reseed should "
+        "preserve them (kept loaded) so it stays seamless (logos#559).",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(
@@ -1000,7 +1014,7 @@ def main(argv: list[str] | None = None) -> None:
     try:
         seeder = HCGSeeder(client)
         if args.clear:
-            seeder.clear()
+            seeder.clear(drop_collections=args.drop_collections)
         if args.ontology_only:
             seeder.seed_type_definitions()
         else:

--- a/logos_hcg/seeder.py
+++ b/logos_hcg/seeder.py
@@ -1004,6 +1004,8 @@ def main(argv: list[str] | None = None) -> None:
         "preserve them (kept loaded) so it stays seamless (logos#559).",
     )
     args = parser.parse_args(argv)
+    if args.drop_collections and not args.clear:
+        parser.error("--drop-collections requires --clear")
 
     logging.basicConfig(
         level=logging.INFO,

--- a/tests/test_seeder_clear_collections.py
+++ b/tests/test_seeder_clear_collections.py
@@ -1,0 +1,27 @@
+"""seeder.clear() must preserve the Milvus collections unless explicitly asked
+to drop them (logos#559 — a #515 regression broke seamless reseed)."""
+
+from unittest.mock import MagicMock, patch
+
+from logos_hcg.seeder import HCGSeeder
+
+
+def test_clear_preserves_collections_by_default():
+    seeder = HCGSeeder(MagicMock())
+    with (
+        patch.object(seeder, "_clear_redis_ontology"),
+        patch.object(HCGSeeder, "_clear_milvus_collections") as drop,
+    ):
+        seeder.clear()
+    drop.assert_not_called()  # collections kept (loaded) -> seamless reseed
+    seeder.client.clear_all.assert_called_once()
+
+
+def test_clear_drops_collections_when_requested():
+    seeder = HCGSeeder(MagicMock())
+    with (
+        patch.object(seeder, "_clear_redis_ontology"),
+        patch.object(HCGSeeder, "_clear_milvus_collections") as drop,
+    ):
+        seeder.clear(drop_collections=True)  # embedding-type change only
+    drop.assert_called_once()

--- a/tests/test_seeder_clear_collections.py
+++ b/tests/test_seeder_clear_collections.py
@@ -3,13 +3,15 @@ to drop them (logos#559 — a #515 regression broke seamless reseed)."""
 
 from unittest.mock import MagicMock, patch
 
-from logos_hcg.seeder import HCGSeeder
+import pytest
+
+from logos_hcg.seeder import HCGSeeder, main
 
 
 def test_clear_preserves_collections_by_default():
     seeder = HCGSeeder(MagicMock())
     with (
-        patch.object(seeder, "_clear_redis_ontology"),
+        patch.object(HCGSeeder, "_clear_redis_ontology"),
         patch.object(HCGSeeder, "_clear_milvus_collections") as drop,
     ):
         seeder.clear()
@@ -20,8 +22,14 @@ def test_clear_preserves_collections_by_default():
 def test_clear_drops_collections_when_requested():
     seeder = HCGSeeder(MagicMock())
     with (
-        patch.object(seeder, "_clear_redis_ontology"),
+        patch.object(HCGSeeder, "_clear_redis_ontology"),
         patch.object(HCGSeeder, "_clear_milvus_collections") as drop,
     ):
         seeder.clear(drop_collections=True)  # embedding-type change only
     drop.assert_called_once()
+
+
+def test_drop_collections_requires_clear():
+    """--drop-collections without --clear is a usage error, not a silent no-op."""
+    with pytest.raises(SystemExit):
+        main(["--drop-collections"])


### PR DESCRIPTION
Fixes #559.

`HCGSeeder.clear()` stopped dropping the Milvus `hcg_*` collections on every reseed (a #515 / `258c54d` regression that broke the previously-seamless reset: dropped collections were lazily re-created by ingest but never `load()`ed → 'collection not loaded' search failures that silently degraded entity-resolution and fully blocked type_emergence/type_rollup).

**Change:** `clear(drop_collections=False)` + a `--drop-collections` CLI flag (default off). Routine reseed preserves the loaded collections; pass the flag only when the embedding type/dim changes (or use `init_milvus_collections.py --force`, which rebuilds + indexes + loads).

**Tests:** added `tests/test_seeder_clear_collections.py` (default preserves, flag drops) — 2 pass; existing seeder tests green; black/ruff clean.