### PR TITLE
feat(hcg): detect types positionally over the IS_A subgraph

### DIFF
--- a/logos_hcg/client.py
+++ b/logos_hcg/client.py
@@ -948,14 +948,16 @@ class HCGClient:
         """
         query = HCGQueries.find_type_definitions()
         records = self._execute_read(query)
-        return [
-            {
-                "uuid": r["uuid"],
-                "name": r["name"],
-                "properties": dict(r["t"]) if r.get("t") else {},
-            }
-            for r in records
-        ]
+        result = []
+        for r in records:
+            props = dict(r["t"]) if r.get("t") else {}
+            # member_count is the positional in-degree (how many nodes IS_A this
+            # type), computed by the query over the IS_A subgraph -- expose it on
+            # properties so callers (e.g. the Redis type snapshot) read the live
+            # count rather than a stale stored prop.
+            props["member_count"] = r.get("member_count", 0)
+            result.append({"uuid": r["uuid"], "name": r["name"], "properties": props})
+        return result
 
     def verify_connection(self) -> bool:
         """

--- a/logos_hcg/client.py
+++ b/logos_hcg/client.py
@@ -950,7 +950,7 @@ class HCGClient:
         records = self._execute_read(query)
         result = []
         for r in records:
-            props = dict(r["t"]) if r.get("t") else {}
+            props = self._parse_node_to_dict(r.get("t"))
             # member_count is the positional in-degree (how many nodes IS_A this
             # type), computed by the query over the IS_A subgraph -- expose it on
             # properties so callers (e.g. the Redis type snapshot) read the live

--- a/logos_hcg/queries.py
+++ b/logos_hcg/queries.py
@@ -24,6 +24,8 @@ Query patterns:
 - Outgoing edges: MATCH (n)<-[:FROM]-(e:Node {type: "edge"})-[:TO]->(target)
 """
 
+import warnings
+
 
 class HCGQueries:
     """Collection of common Cypher queries for HCG operations."""
@@ -289,21 +291,34 @@ class HCGQueries:
     @staticmethod
     def find_type_definition() -> str:
         """
-        Find a type by name, positionally.
+        .. deprecated::
+            Resolve a type by uuid, or via ``find_type_definitions()`` / the
+            name->uuid type snapshot. Names are NOT unique in the HCG (e.g.
+            duplicate ``cognition``/``concept`` nodes exist), so a singular
+            by-name type lookup is inherently ambiguous -- this can return
+            MORE THAN ONE node for a single name, which a caller expecting a
+            single type definition cannot use safely.
 
-        Consistent with find_type_definitions(): a type is any node that
-        something IS_A's. Resolving by name therefore matches a node named
-        ``$name`` that has an incoming reified IS_A edge -- so it can find
-        positionally-discovered types like ``engine``, not just label-stamped
-        ones. (The old ``{type:"type_definition"}`` filter would silently miss
-        every type the plural query now surfaces.)
+        Find a type by name, positionally. Kept consistent with
+        ``find_type_definitions()`` (positional over the IS_A subgraph) so that
+        a caller ignoring the deprecation at least does not silently miss
+        positionally-discovered types like ``engine`` the way the old
+        ``{type:"type_definition"}`` filter would have. ``DISTINCT`` collapses
+        the duplicate rows a node accrues from its multiple incoming IS_A edges.
 
         Parameters:
         - name: Type name
 
-        Returns: the type node(s) named ``name``. DISTINCT collapses the
-        duplicate rows a node accrues from its multiple incoming IS_A edges.
+        Returns: the type node(s) named ``name``.
         """
+        warnings.warn(
+            "HCGQueries.find_type_definition (singular, by-name) is "
+            "deprecated: names are not unique in the HCG, so by-name type "
+            "resolution is ambiguous. Resolve by uuid, or via "
+            "find_type_definitions()/the type snapshot.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return """
         MATCH (:Node {relation: "IS_A"})-[:TO]->(t:Node {name: $name})
         WHERE t.relation IS NULL

--- a/logos_hcg/queries.py
+++ b/logos_hcg/queries.py
@@ -289,16 +289,25 @@ class HCGQueries:
     @staticmethod
     def find_type_definition() -> str:
         """
-        Find a type definition by name.
+        Find a type by name, positionally.
+
+        Consistent with find_type_definitions(): a type is any node that
+        something IS_A's. Resolving by name therefore matches a node named
+        ``$name`` that has an incoming reified IS_A edge -- so it can find
+        positionally-discovered types like ``engine``, not just label-stamped
+        ones. (The old ``{type:"type_definition"}`` filter would silently miss
+        every type the plural query now surfaces.)
 
         Parameters:
         - name: Type name
 
-        Returns: Type definition node
+        Returns: the type node(s) named ``name``. DISTINCT collapses the
+        duplicate rows a node accrues from its multiple incoming IS_A edges.
         """
         return """
-        MATCH (t:Node {type: "type_definition", name: $name})
-        RETURN t
+        MATCH (:Node {relation: "IS_A"})-[:TO]->(t:Node {name: $name})
+        WHERE t.relation IS NULL
+        RETURN DISTINCT t
         """
 
     @staticmethod

--- a/logos_hcg/queries.py
+++ b/logos_hcg/queries.py
@@ -265,14 +265,24 @@ class HCGQueries:
     @staticmethod
     def find_type_definitions() -> str:
         """
-        Find all type definition nodes.
-        Type definitions are nodes with type="type_definition".
+        Find all types, positionally, over the IS_A subgraph.
 
-        Returns: List of type definition nodes with name and uuid.
+        A type is any node that something IS_A's -- i.e. it has an incoming
+        reified IS_A edge (an edge-node ``{relation:"IS_A"}`` whose ``:TO`` points
+        at it). This structural definition replaces the stored
+        ``type="type_definition"`` label, so it also surfaces content-node types
+        (e.g. ``engine`` once ``turbofan IS_A engine`` exists), not just minted/
+        seeded ones. The query is anchored on the IS_A edge-nodes (uses the
+        ``Node.relation`` index) and touches ONLY the IS_A subgraph; ``member_count``
+        is the in-degree (how many nodes IS_A this type).
+
+        Returns: each type's name, uuid, node (``t``), and member_count.
         """
         return """
-        MATCH (t:Node {type: "type_definition"})
-        RETURN t.name AS name, t.uuid AS uuid, t
+        MATCH (:Node {relation: "IS_A"})-[:TO]->(t:Node)
+        WHERE t.relation IS NULL
+        WITH t, count(*) AS member_count
+        RETURN t.name AS name, t.uuid AS uuid, t, member_count
         ORDER BY t.name
         """
 

--- a/tests/test_queries_reified.py
+++ b/tests/test_queries_reified.py
@@ -1,5 +1,7 @@
 """Integration tests for reified edge queries. Requires Neo4j."""
 
+import warnings
+
 import pytest
 
 from logos_hcg.client import HCGClient
@@ -240,7 +242,13 @@ class TestAncestorPropertyRemoved:
             method = getattr(HCGQueries, name)
             if callable(method):
                 try:
-                    q = method()
+                    # Some methods (e.g. the deprecated singular
+                    # find_type_definition) emit a DeprecationWarning when
+                    # called; inspecting their query strings shouldn't trip on
+                    # that under warnings-as-error.
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore", DeprecationWarning)
+                        q = method()
                     if isinstance(q, str):
                         queries.append((name, q))
                 except TypeError:


### PR DESCRIPTION
## What

`find_type_definitions()` now identifies a type **positionally**: any node with an incoming reified `IS_A` edge (a node something `IS_A`'s), rather than a node stamped `type="type_definition"`.

## Why

The stored `type_definition` label can't capture two real cases:
1. **Content-node types** — `engine` is just as much a type as `entity` once `turbofan IS_A engine` exists, but it was never label-stamped.
2. **Become-a-type-after-graft** — a node becomes a type the moment something is grafted under it; a stored label set at mint time can't reflect that.

Membership IS the edge (DESIGN §3), so the type layer should be read from the edge topology.

## How

- Query anchored on the `IS_A` edge-nodes (uses the `Node.relation` index), touching **only** the IS_A subgraph.
- Returns `member_count` = in-degree (how many nodes `IS_A` this type). `get_all_type_definitions()` folds it into each record's `properties`, so callers (e.g. the Redis type snapshot Hermes boots from) read the **live** count, not a stale stored prop.
- Shape is a **superset** of the old contract (`member_count` added); existing callers using `name`/`uuid`/`t` are unaffected.

## Validation

- No-DB query-safety tests pass.
- Read-only execution against the live graph returns **55 types**, incl. `entity(5162)`, `concept(316)`, `process(172)` and the fine-grained `engine(5)`, `protein(3)`, `machine(2)` that the label-based query missed.

Part of the typing rework. Follow-up #205 (sophia) removes the `type_` uuid encoding and makes `type_rollup` positional.